### PR TITLE
Audit 6 - 2 Step process for critical ops

### DIFF
--- a/src/ErrorSelectors.md
+++ b/src/ErrorSelectors.md
@@ -111,3 +111,4 @@ An online Keccak-256 hash digester can be found at https://emn178.github.io/onli
 | 0x6d12e45a | MinimumHoldTimePeriodNotReached()                                |
 | 0x771d7f93 | PeriodExceeds5Years()                                            |
 | 0x41284967 | ConfirmerDoesNotMatchProposedAddress()                           |
+| 0x821e0eeb | NoProposalHasBeenMade()                                          |

--- a/src/ErrorSelectors.md
+++ b/src/ErrorSelectors.md
@@ -110,3 +110,4 @@ An online Keccak-256 hash digester can be found at https://emn178.github.io/onli
 | 0x81af27fa | TotalSupplyVolatilityLimitReached()                              |
 | 0x6d12e45a | MinimumHoldTimePeriodNotReached()                                |
 | 0x771d7f93 | PeriodExceeds5Years()                                            |
+| 0x41284967 | ConfirmerDoesNotMatchProposedAddress()                           |

--- a/src/application/AppManager.sol
+++ b/src/application/AppManager.sol
@@ -2,20 +2,21 @@
 pragma solidity 0.8.17;
 
 import "openzeppelin-contracts/contracts/access/AccessControlEnumerable.sol";
-import "../data/Accounts.sol";
-import "../data/IAccounts.sol";
-import "../data/IAccessLevels.sol";
-import "../data/AccessLevels.sol";
-import "../data/IRiskScores.sol";
-import "../data/RiskScores.sol";
-import "../data/IGeneralTags.sol";
-import "../data/GeneralTags.sol";
-import "../data/IPauseRules.sol";
-import "../data/PauseRules.sol";
-import "./ProtocolApplicationHandler.sol";
+import "src/data/Accounts.sol";
+import "src/data/IAccounts.sol";
+import "src/data/IAccessLevels.sol";
+import "src/data/AccessLevels.sol";
+import "src/data/IRiskScores.sol";
+import "src/data/RiskScores.sol";
+import "src/data/IGeneralTags.sol";
+import "src/data/GeneralTags.sol";
+import "src/data/IPauseRules.sol";
+import "src/data/PauseRules.sol";
+import "src/application/ProtocolApplicationHandler.sol";
 import "src/economic/ruleProcessor/ActionEnum.sol";
-import {IAppLevelEvents} from "../interfaces/IEvents.sol";
-import "./IAppManagerUser.sol";
+import {IAppLevelEvents} from "src/interfaces/IEvents.sol";
+import "src/application/IAppManagerUser.sol";
+import "src/data/IDataModule.sol";
 
 /**
  * @title App Manager Contract
@@ -35,6 +36,13 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     IRiskScores riskScores;
     IGeneralTags generalTags;
     IPauseRules pauseRules;
+
+    // Data provider proposed addresses
+    address newAccessLevelsProviderAddress;
+    address newAccountsProviderAddress;
+    address newGeneralTagsProviderAddress;
+    address newPauseRulesProviderAddress;
+    address newRiskScoresProviderAddress;
 
     /// Application Handler Contract
     ProtocolApplicationHandler public applicationHandler;
@@ -462,29 +470,29 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     }
 
     /**
-     * @dev  Set the address of the Risk Provider contract. Restricted to Application Administrators
-     * @param _provider Address of the provider
+     * @dev  First part of the 2 step process to set a new risk score provider. First, the new provider address is proposed and saved, then it is confirmed by invoking a confirmation function in the new provider that invokes the corresponding function in this contract.
+     * @param _newProvider Address of the new provider
      */
-    function setRiskProvider(address _provider) external onlyAppAdministrator {
-        if (_provider == address(0)) revert ZeroAddress();
-        riskScores = IRiskScores(_provider);
+    function proposeRiskScoresProvider(address _newProvider) external onlyAppAdministrator {
+        if (_newProvider == address(0)) revert ZeroAddress();
+        newRiskScoresProviderAddress = _newProvider;
     }
 
     /**
      * @dev Get the address of the risk score provider
      * @return provider Address of the provider
      */
-    function getRiskProvider() external view returns (address) {
+    function getRiskScoresProvider() external view returns (address) {
         return address(riskScores);
     }
 
     /**
-     * @dev  Set the address of the General Tag Provider contract. Restricted to Application Administrators
-     * @param _provider Address of the provider
+     * @dev  First part of the 2 step process to set a new general tag provider. First, the new provider address is proposed and saved, then it is confirmed by invoking a confirmation function in the new provider that invokes the corresponding function in this contract.
+     * @param _newProvider Address of the new provider
      */
-    function setGeneralTagProvider(address _provider) external onlyAppAdministrator {
-        if (_provider == address(0)) revert ZeroAddress();
-        generalTags = IGeneralTags(_provider);
+    function proposeGeneralTagsProvider(address _newProvider) external onlyAppAdministrator {
+        if (_newProvider == address(0)) revert ZeroAddress();
+        newGeneralTagsProviderAddress = _newProvider;
     }
 
     /**
@@ -496,12 +504,12 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     }
 
     /**
-     * @dev  Set the address of the Account Provider contract. Restricted to Application Administrators
-     * @param _provider Address of the provider
+     * @dev  First part of the 2 step process to set a new account provider. First, the new provider address is proposed and saved, then it is confirmed by invoking a confirmation function in the new provider that invokes the corresponding function in this contract.
+     * @param _newProvider Address of the new provider
      */
-    function setAccountProvider(address _provider) external onlyAppAdministrator {
-        if (_provider == address(0)) revert ZeroAddress();
-        accounts = IAccounts(_provider);
+    function proposeAccountsProvider(address _newProvider) external onlyAppAdministrator {
+        if (_newProvider == address(0)) revert ZeroAddress();
+        newAccountsProviderAddress = _newProvider;
     }
 
     /**
@@ -513,12 +521,12 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     }
 
     /**
-     * @dev  Set the address of the Pause Rule Provider contract. Restricted to Application Administrators
-     * @param _provider Address of the provider
+     * @dev  First part of the 2 step process to set a new pause rule provider. First, the new provider address is proposed and saved, then it is confirmed by invoking a confirmation function in the new provider that invokes the corresponding function in this contract.
+     * @param _newProvider Address of the new provider
      */
-    function setPauseRuleProvider(address _provider) external onlyAppAdministrator {
-        if (_provider == address(0)) revert ZeroAddress();
-        pauseRules = IPauseRules(_provider);
+    function proposePauseRulesProvider(address _newProvider) external onlyAppAdministrator {
+        if (_newProvider == address(0)) revert ZeroAddress();
+        newPauseRulesProviderAddress = _newProvider;
     }
 
     /**
@@ -530,12 +538,12 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     }
 
     /**
-     * @dev  Set the address of the Access Level Provider contract. Restricted to Application Administrators
-     * @param _accessLevelProvider Address of the Access Level provider
+     * @dev  First part of the 2 step process to set a new access level provider. First, the new provider address is proposed and saved, then it is confirmed by invoking a confirmation function in the new provider that invokes the corresponding function in this contract.
+     * @param _newProvider Address of the new provider
      */
-    function setAccessLevelProvider(address _accessLevelProvider) external onlyAppAdministrator {
-        if (_accessLevelProvider == address(0)) revert ZeroAddress();
-        accessLevels = IAccessLevels(_accessLevelProvider);
+    function proposeAccessLevelsProvider(address _newProvider) external onlyAppAdministrator {
+        if (_newProvider == address(0)) revert ZeroAddress();
+        newAccessLevelsProviderAddress = _newProvider;
     }
 
     /**
@@ -823,42 +831,74 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
      * @dev Deploy all the child data contracts. Only called internally from the constructor.
      */
     function deployDataContracts() private {
-        accounts = new Accounts();
-        accessLevels = new AccessLevels();
-        riskScores = new RiskScores();
-        generalTags = new GeneralTags();
-        pauseRules = new PauseRules();
+        accounts = new Accounts(address(this));
+        accessLevels = new AccessLevels(address(this));
+        riskScores = new RiskScores(address(this));
+        generalTags = new GeneralTags(address(this));
+        pauseRules = new PauseRules(address(this));
     }
 
     /**
-     * @dev This function is used to migrate the data contracts to a new AppManager. Use with care because it changes ownership. They will no
-     * longer be accessible from the original AppManager
+     * @dev This function is used to propose the new owner for data contracts.
      * @param _newOwner address of the new AppManager
      */
-    function migrateDataContracts(address _newOwner) external onlyAppAdministrator {
-        accounts.setAppManagerAddress(_newOwner);
-        accounts.transferDataOwnership(_newOwner);
-        accessLevels.setAppManagerAddress(_newOwner);
-        accessLevels.transferDataOwnership(_newOwner);
-        riskScores.setAppManagerAddress(_newOwner);
-        riskScores.transferDataOwnership(_newOwner);
-        generalTags.setAppManagerAddress(_newOwner);
-        generalTags.transferDataOwnership(_newOwner);
-        pauseRules.setAppManagerAddress(_newOwner);
-        pauseRules.transferDataOwnership(_newOwner);
-        emit AppManagerUpgrade(_newOwner, address(this));
+    function proposeDataContractMigration(address _newOwner) external onlyAppAdministrator {
+        accounts.proposeOwner(_newOwner);
+        accessLevels.proposeOwner(_newOwner);
+        riskScores.proposeOwner(_newOwner);
+        generalTags.proposeOwner(_newOwner);
+        pauseRules.proposeOwner(_newOwner);
+        emit AppManagerDataUpgradeProposed(_newOwner, address(this));
     }
 
     /**
-     * @dev This function is used to connect data contracts from an old AppManager to the current AppManager.
-     * @param _oldAppManagerAddress address of the old AppManager
+     * @dev This function is used to confirm this contract as the new owner for data contracts.
      */
-    function connectDataContracts(address _oldAppManagerAddress) external onlyAppAdministrator {
+    function confirmDataContractMigration(address _oldAppManagerAddress) external onlyAppAdministrator {
         AppManager oldAppManager = AppManager(_oldAppManagerAddress);
         accounts = Accounts(oldAppManager.getAccountDataAddress());
+        accounts.confirmOwner();
         accessLevels = IAccessLevels(oldAppManager.getAccessLevelDataAddress());
+        accessLevels.confirmOwner();
         riskScores = RiskScores(oldAppManager.getRiskDataAddress());
+        riskScores.confirmOwner();
         generalTags = GeneralTags(oldAppManager.getGeneralTagsDataAddress());
+        generalTags.confirmOwner();
         pauseRules = PauseRules(oldAppManager.getPauseRulesDataAddress());
+        pauseRules.confirmOwner();
+        emit DataContractsMigrated(address(this));
+    }
+
+    /**
+     * @dev Part of the two step process to set a new Data Provider within a Protocol AppManager. Final confirmation called by new provider
+     * @param _providerType the type of data provider
+     */
+    function confirmNewDataProvider(IDataModule.ProviderType _providerType) external {
+        if (_providerType == IDataModule.ProviderType.GENERAL_TAG) {
+            if (newGeneralTagsProviderAddress == address(0)) revert NoProposalHasBeenMade();
+            if (msg.sender != newGeneralTagsProviderAddress) revert ConfirmerDoesNotMatchProposedAddress();
+            generalTags = IGeneralTags(newGeneralTagsProviderAddress);
+            delete newGeneralTagsProviderAddress;
+        } else if (_providerType == IDataModule.ProviderType.RISK_SCORE) {
+            if (newRiskScoresProviderAddress == address(0)) revert NoProposalHasBeenMade();
+            if (msg.sender != newRiskScoresProviderAddress) revert ConfirmerDoesNotMatchProposedAddress();
+            riskScores = IRiskScores(newRiskScoresProviderAddress);
+            delete newRiskScoresProviderAddress;
+        } else if (_providerType == IDataModule.ProviderType.ACCESS_LEVEL) {
+            if (newAccessLevelsProviderAddress == address(0)) revert NoProposalHasBeenMade();
+            if (msg.sender != newAccessLevelsProviderAddress) revert ConfirmerDoesNotMatchProposedAddress();
+            accessLevels = IAccessLevels(newAccessLevelsProviderAddress);
+            delete newAccessLevelsProviderAddress;
+        } else if (_providerType == IDataModule.ProviderType.ACCOUNT) {
+            if (newAccountsProviderAddress == address(0)) revert NoProposalHasBeenMade();
+            if (msg.sender != newAccountsProviderAddress) revert ConfirmerDoesNotMatchProposedAddress();
+            accounts = IAccounts(newAccountsProviderAddress);
+            delete newAccountsProviderAddress;
+        } else if (_providerType == IDataModule.ProviderType.PAUSE_RULE) {
+            if (newPauseRulesProviderAddress == address(0)) revert NoProposalHasBeenMade();
+            if (msg.sender != newPauseRulesProviderAddress) revert ConfirmerDoesNotMatchProposedAddress();
+            pauseRules = IPauseRules(newPauseRulesProviderAddress);
+            delete newPauseRulesProviderAddress;
+        }
     }
 }

--- a/src/application/AppManager.sol
+++ b/src/application/AppManager.sol
@@ -15,6 +15,7 @@ import "../data/PauseRules.sol";
 import "./ProtocolApplicationHandler.sol";
 import "src/economic/ruleProcessor/ActionEnum.sol";
 import {IAppLevelEvents} from "../interfaces/IEvents.sol";
+import "./IAppManagerUser.sol";
 
 /**
  * @title App Manager Contract
@@ -23,8 +24,6 @@ import {IAppLevelEvents} from "../interfaces/IEvents.sol";
  * @notice This contract is the permissions contract
  */
 contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
-    
-
     bytes32 constant USER_ROLE = keccak256("USER");
     bytes32 constant APP_ADMIN_ROLE = keccak256("APP_ADMIN_ROLE");
     bytes32 constant ACCESS_TIER_ADMIN_ROLE = keccak256("ACCESS_TIER_ADMIN_ROLE");
@@ -369,7 +368,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
      * @param _pauseStop End of the pause window
      */
     function addPauseRule(uint256 _pauseStart, uint256 _pauseStop) external onlyAppAdministrator {
-        
         pauseRules.addPauseRule(_pauseStart, _pauseStop);
     }
 
@@ -416,14 +414,14 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
      * @notice there is a hard limit of 10 tags per address.
      */
     function addGeneralTagToMultipleAccounts(address[] memory _accounts, bytes32 _tag) external onlyAppAdministrator {
-         generalTags.addGeneralTagToMultipleAccounts(_accounts, _tag);
+        generalTags.addGeneralTagToMultipleAccounts(_accounts, _tag);
     }
 
     /**
      * @dev Add a general tag to an account at index in array. Restricted to Application Administrators. Loops through existing tags on accounts and will emit  an event if tag is already applied.
      * @param _accounts Address array to be tagged
      * @param _tag Tag array for the account at index. Can be any allowed string variant
-     * @notice there is a hard limit of 10 tags per address. 
+     * @notice there is a hard limit of 10 tags per address.
      */
     function addMultipleGeneralTagToMultipleAccounts(address[] memory _accounts, bytes32[] memory _tag) external onlyAppAdministrator {
         if (_accounts.length != _tag.length) revert InputArraysMustHaveSameLength();
@@ -793,7 +791,7 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     function setNewApplicationHandlerAddress(address _newApplicationHandler) external onlyAppAdministrator {
         applicationHandler = ProtocolApplicationHandler(_newApplicationHandler);
         applicationHandlerAddress = _newApplicationHandler;
-        emit HandlerConnected( applicationHandlerAddress, address(this)); 
+        emit HandlerConnected(applicationHandlerAddress, address(this));
     }
 
     /**
@@ -810,6 +808,14 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
      */
     function setAppName(string calldata _appName) external onlyAppAdministrator {
         appName = _appName;
+    }
+
+    /**
+     * @dev Part of the two step process to set a new AppManager within a Protocol Entity
+     * @param _assetAddress address of a protocol entity that uses AppManager
+     */
+    function confirmAppManager(address _assetAddress) external onlyAppAdministrator {
+        IAppManagerUser(_assetAddress).confirmAppManagerAddress();
     }
 
     /// -------------DATA CONTRACT DEPLOYMENT---------------

--- a/src/application/IAppManager.sol
+++ b/src/application/IAppManager.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-
 import "src/economic/ruleProcessor/ActionEnum.sol";
-import "../data/IPauseRules.sol";
-import { IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
+import "src/data/IDataModule.sol";
+import "src/data/IPauseRules.sol";
+import {IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddressError, IOwnershipErrors} from "src/interfaces/IErrors.sol";
 
 /**
  * @title App Manager Inquiry Interface
@@ -12,7 +12,7 @@ import { IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddr
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  * @notice Interface for app manager server functions.
  */
-interface IAppManager is IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddressError {
+interface IAppManager is IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddressError, IOwnershipErrors {
     /**
      * @dev This function is where the default admin role is actually checked
      * @param account address to be checked
@@ -173,4 +173,10 @@ interface IAppManager is IAppManagerErrors, IAppAdministratorOnlyErrors, IInputE
      * @return true if one or more rules are active
      */
     function requireValuations() external returns (bool);
+
+    /**
+     * @dev Part of the two step process to set a new Data Provider within a Protocol AppManager. Final confirmation called by new provider
+     * @param _providerType the type of data provider
+     */
+    function confirmNewDataProvider(IDataModule.ProviderType _providerType) external;
 }

--- a/src/application/IAppManagerUser.sol
+++ b/src/application/IAppManagerUser.sol
@@ -9,7 +9,7 @@ pragma solidity 0.8.17;
  */
 interface IAppManagerUser {
     /**
-     * @dev this function confirms a new appManagerAddress that was put in storageIt can only be confirmed by the proposed address
+     * @dev This function confirms a new appManagerAddress that was put in storage. It can only be confirmed by the proposed address
      */
     function confirmAppManagerAddress() external;
 }

--- a/src/application/IAppManagerUser.sol
+++ b/src/application/IAppManagerUser.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+/**
+ * @title App Manager User Interface
+ * @dev This interface is implemented by all contracts that use AppManager. It provides the common function for setting up a new link to an AppManager
+ * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
+ * @notice Interface for app manager user functions.
+ */
+interface IAppManagerUser {
+    /**
+     * @dev this function confirms a new appManagerAddress that was put in storageIt can only be confirmed by the proposed address
+     */
+    function confirmAppManagerAddress() external;
+}

--- a/src/data/AccessLevels.sol
+++ b/src/data/AccessLevels.sol
@@ -15,9 +15,11 @@ contract AccessLevels is IAccessLevels, DataModule {
 
     /**
      * @dev Constructor that sets the app manager address used for permissions. This is required for upgrades.
+     * @param _dataModuleAppManagerAddress address of the owning app manager
      */
-    constructor() {
-        dataModuleAppManagerAddress = owner();
+    constructor(address _dataModuleAppManagerAddress) {
+        dataModuleAppManagerAddress = _dataModuleAppManagerAddress;
+        _transferOwnership(dataModuleAppManagerAddress);
     }
 
     /**
@@ -25,7 +27,7 @@ contract AccessLevels is IAccessLevels, DataModule {
      * @param _address address of the account
      * @param _level access levellevel(0-4)
      */
-    function addLevel(address _address, uint8 _level) public onlyOwner {
+    function addLevel(address _address, uint8 _level) public virtual onlyOwner {
         if (_level > 4) revert AccessLevelIsNotValid(_level);
         levels[_address] = _level;
         emit AccessLevelAdded(_address, _level, block.timestamp);
@@ -36,7 +38,7 @@ contract AccessLevels is IAccessLevels, DataModule {
      * @param _accounts address upon which to apply the Access Level
      * @param _level Access Level to add
      */
-    function addAccessLevelToMultipleAccounts(address[] memory _accounts, uint8 _level) external onlyOwner {
+    function addAccessLevelToMultipleAccounts(address[] memory _accounts, uint8 _level) external virtual onlyOwner {
         if (_level > 4) revert AccessLevelIsNotValid(_level);
         for (uint256 i; i < _accounts.length; ) {
             levels[_accounts[i]] = _level;
@@ -51,7 +53,7 @@ contract AccessLevels is IAccessLevels, DataModule {
      * @dev Remove the Access Level for the account. Restricted to the owner
      * @param _account address of the account
      */
-    function removelevel(address _account) external onlyOwner {
+    function removelevel(address _account) external virtual onlyOwner {
         delete levels[_account];
         emit AccessLevelRemoved(_account, block.timestamp);
     }
@@ -61,7 +63,7 @@ contract AccessLevels is IAccessLevels, DataModule {
      * @param _account address of the account
      * @return level Access Level(0-4)
      */
-    function getAccessLevel(address _account) external view returns (uint8) {
+    function getAccessLevel(address _account) external view virtual returns (uint8) {
         return (levels[_account]);
     }
 
@@ -70,7 +72,7 @@ contract AccessLevels is IAccessLevels, DataModule {
      * @param _address address of the account
      * @return hasAccessLevel true if it has a level, false if it doesn't
      */
-    function hasAccessLevel(address _address) external view returns (bool) {
+    function hasAccessLevel(address _address) external view virtual returns (bool) {
         return levels[_address] > 0;
     }
 }

--- a/src/data/Accounts.sol
+++ b/src/data/Accounts.sol
@@ -10,21 +10,22 @@ import "./IAccounts.sol";
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
 contract Accounts is DataModule, IAccounts {
-
     mapping(address => bool) public accounts;
 
     /**
      * @dev Constructor that sets the app manager address used for permissions. This is required for upgrades.
+     * @param _dataModuleAppManagerAddress address of the owning app manager
      */
-    constructor() {
-        dataModuleAppManagerAddress = owner();
+    constructor(address _dataModuleAppManagerAddress) {
+        dataModuleAppManagerAddress = _dataModuleAppManagerAddress;
+        _transferOwnership(dataModuleAppManagerAddress);
     }
 
     /**
      * @dev Add the account. Restricted to owner.
      * @param _account user address
      */
-    function addAccount(address _account) external onlyOwner {
+    function addAccount(address _account) external virtual onlyOwner {
         if (_account == address(0)) revert ZeroAddress();
         accounts[_account] = true;
         emit AccountAdded(_account, block.timestamp);
@@ -34,7 +35,7 @@ contract Accounts is DataModule, IAccounts {
      * @dev Remove the account. Restricted to owner.
      * @param _account user address
      */
-    function removeAccount(address _account) external onlyOwner {
+    function removeAccount(address _account) external virtual onlyOwner {
         accounts[_account] = false;
         emit AccountRemoved(_account, block.timestamp);
     }
@@ -44,7 +45,7 @@ contract Accounts is DataModule, IAccounts {
      * @param _address user address
      * @return exists true if exists, false if not exists
      */
-    function isUserAccount(address _address) external view returns (bool) {
+    function isUserAccount(address _address) external view virtual returns (bool) {
         return accounts[_address];
     }
 }

--- a/src/data/DataModule.sol
+++ b/src/data/DataModule.sol
@@ -3,7 +3,8 @@ pragma solidity 0.8.17;
 
 import "./IDataModule.sol";
 import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import {IAppManager} from "../application/IAppManager.sol";
+import {IAppManager} from "src/application/IAppManager.sol";
+import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 
 /**
  * @title Data Module
@@ -11,9 +12,11 @@ import {IAppManager} from "../application/IAppManager.sol";
  * @dev Allows for proper permissioning for both internal and external data sources.
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
-contract DataModule is IDataModule, Ownable {
+contract DataModule is IDataModule, Ownable, IOwnershipErrors, IZeroAddressError {
     ///Data Module
     address public dataModuleAppManagerAddress;
+    address newOwner; // This is used for data contract migration
+    address newDataProviderOwner; // this is used for single new data provider
 
     /**
      * @dev Modifier ensures function caller is a Application Administrators or the parent contract
@@ -27,19 +30,28 @@ contract DataModule is IDataModule, Ownable {
     }
 
     /**
-     * @dev updates the dataModuleAppManagerAddress value
-     * @param _appManagerAddress New address
-     * @notice only app administrators or owner of this contract can invoke this function successfully.
+     * @dev this function proposes a new owner that is put in storage to be confirmed in a separate process
+     * @param _newOwner the new address being proposed
      */
-    function setAppManagerAddress(address _appManagerAddress) external appAdminstratorOrOwnerOnly {
-        dataModuleAppManagerAddress = _appManagerAddress;
+    function proposeOwner(address _newOwner) external appAdminstratorOrOwnerOnly {
+        if (_newOwner == address(0)) revert ZeroAddress();
+        newOwner = _newOwner;
     }
 
     /**
-     * @dev Transfers ownership of the contract to a new account (`newOwner`).
-     * Can only be called by the current owner.
+     * @dev this function confirms a new appManagerAddress that was put in storage. It can only be confirmed by the proposed address
      */
-    function transferDataOwnership(address newOwner) public appAdminstratorOrOwnerOnly {
-        transferOwnership(newOwner);
+    function confirmOwner() external {
+        if (newOwner == address(0)) revert NoProposalHasBeenMade();
+        if (msg.sender != newOwner) revert ConfirmerDoesNotMatchProposedAddress();
+        _transferOwnership(newOwner);
+    }
+
+    /**
+     * @dev Part of the two step process to set a new Data Provider within a Protocol AppManager
+     * @param _providerType the type of data provider
+     */
+    function confirmDataProvider(ProviderType _providerType) external virtual appAdminstratorOrOwnerOnly {
+        IAppManager(dataModuleAppManagerAddress).confirmNewDataProvider(_providerType);
     }
 }

--- a/src/data/GeneralTags.sol
+++ b/src/data/GeneralTags.sol
@@ -10,14 +10,15 @@ import "./IGeneralTags.sol";
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
 contract GeneralTags is DataModule, IGeneralTags {
-
     mapping(address => bytes32[]) public tagRecords;
 
     /**
      * @dev Constructor that sets the app manager address used for permissions. This is required for upgrades.
+     * @param _dataModuleAppManagerAddress address of the owning app manager
      */
-    constructor() {
-        dataModuleAppManagerAddress = owner();
+    constructor(address _dataModuleAppManagerAddress) {
+        dataModuleAppManagerAddress = _dataModuleAppManagerAddress;
+        _transferOwnership(dataModuleAppManagerAddress);
     }
 
     /**
@@ -27,11 +28,11 @@ contract GeneralTags is DataModule, IGeneralTags {
      * @notice there is a hard limit of 10 tags per address. This limit is also enforced by the
      * protocol, so keeping this limit here prevents transfers to unexpectedly revert.
      */
-    function addTag(address _address, bytes32 _tag) public onlyOwner {
-        if(_tag == "") revert BlankTag();
+    function addTag(address _address, bytes32 _tag) public virtual onlyOwner {
+        if (_tag == "") revert BlankTag();
         if (hasTag(_address, _tag)) emit TagAlreadyApplied(_address);
         else {
-            if( tagRecords[_address].length >= 10) revert MaxTagLimitReached();
+            if (tagRecords[_address].length >= 10) revert MaxTagLimitReached();
             tagRecords[_address].push(_tag);
             emit GeneralTagAdded(_address, _tag, block.timestamp);
         }
@@ -44,12 +45,12 @@ contract GeneralTags is DataModule, IGeneralTags {
      * @notice there is a hard limit of 10 tags per address. This limit is also enforced by the
      * protocol, so keeping this limit here prevents transfers to unexpectedly revert.
      */
-    function addGeneralTagToMultipleAccounts(address[] memory _accounts, bytes32 _tag) external onlyOwner {
-        if(_tag == "") revert BlankTag();
+    function addGeneralTagToMultipleAccounts(address[] memory _accounts, bytes32 _tag) external virtual onlyOwner {
+        if (_tag == "") revert BlankTag();
         for (uint256 i; i < _accounts.length; ) {
             if (hasTag(_accounts[i], _tag)) emit TagAlreadyApplied(_accounts[i]);
-            else{
-                if( tagRecords[_accounts[i]].length >= 10) revert MaxTagLimitReached();
+            else {
+                if (tagRecords[_accounts[i]].length >= 10) revert MaxTagLimitReached();
                 tagRecords[_accounts[i]].push(_tag);
                 emit GeneralTagAdded(_accounts[i], _tag, block.timestamp);
             }
@@ -64,7 +65,7 @@ contract GeneralTags is DataModule, IGeneralTags {
      * @param _address of the account to remove tag
      * @param i index of the tag to remove
      */
-    function _removeTag(address _address, uint256 i) internal {
+    function _removeTag(address _address, uint256 i) internal virtual {
         uint256 tagCount = tagRecords[_address].length;
         tagRecords[_address][i] = tagRecords[_address][tagCount - 1];
         tagRecords[_address].pop();
@@ -75,7 +76,7 @@ contract GeneralTags is DataModule, IGeneralTags {
      * @param _address user address
      * @param _tag metadata tag to be removed
      */
-    function removeTag(address _address, bytes32 _tag) external onlyOwner {
+    function removeTag(address _address, bytes32 _tag) external virtual onlyOwner {
         uint256 i;
         while (i < tagRecords[_address].length) {
             while (tagRecords[_address].length > 0 && i < tagRecords[_address].length && keccak256(abi.encodePacked(tagRecords[_address][i])) == keccak256(abi.encodePacked(_tag))) {
@@ -94,7 +95,7 @@ contract GeneralTags is DataModule, IGeneralTags {
      * @param _tag metadata tag
      * @return hasTag true if it has the tag, false if it doesn't
      */
-    function hasTag(address _address, bytes32 _tag) public view returns (bool) {
+    function hasTag(address _address, bytes32 _tag) public view virtual returns (bool) {
         for (uint256 i = 0; i < tagRecords[_address].length; ) {
             if (keccak256(abi.encodePacked(tagRecords[_address][i])) == keccak256(abi.encodePacked(_tag))) {
                 return true;
@@ -107,7 +108,7 @@ contract GeneralTags is DataModule, IGeneralTags {
     }
 
     // Get all the tags for the address
-    function getAllTags(address _address) public view returns (bytes32[] memory) {
+    function getAllTags(address _address) public view virtual returns (bytes32[] memory) {
         return tagRecords[_address];
     }
 }

--- a/src/data/IDataModule.sol
+++ b/src/data/IDataModule.sol
@@ -13,12 +13,28 @@ interface IDataModule is IAppLevelEvents {
     ///Data Module
     error AppManagerNotConnected();
     error NotAppAdministratorOrOwner();
-
-    function setAppManagerAddress(address _appManagerAddress) external;
+    enum ProviderType {
+        ACCESS_LEVEL,
+        ACCOUNT,
+        GENERAL_TAG,
+        PAUSE_RULE,
+        RISK_SCORE
+    }
 
     /**
-     * @dev Transfers ownership of the contract to a new account (`newOwner`).
-     * Can only be called by the current owner.
+     * @dev this function proposes a new owner that is put in storage to be confirmed in a separate process
+     * @param _newOwner the new address being proposed
      */
-    function transferDataOwnership(address newOwner) external;
+    function proposeOwner(address _newOwner) external;
+
+    /**
+     * @dev this function confirms a new appManagerAddress that was put in storageIt can only be confirmed by the proposed address
+     */
+    function confirmOwner() external;
+
+    /**
+     * @dev Part of the two step process to set a new Data Provider within a Protocol AppManager
+     * @param _providerType the type of data provider
+     */
+    function confirmDataProvider(ProviderType _providerType) external;
 }

--- a/src/data/PauseRules.sol
+++ b/src/data/PauseRules.sol
@@ -15,9 +15,11 @@ contract PauseRules is IPauseRules, DataModule {
 
     /**
      * @dev Constructor that sets the app manager address used for permissions. This is required for upgrades.
+     * @param _dataModuleAppManagerAddress address of the owning app manager
      */
-    constructor() {
-        dataModuleAppManagerAddress = owner();
+    constructor(address _dataModuleAppManagerAddress) {
+        dataModuleAppManagerAddress = _dataModuleAppManagerAddress;
+        _transferOwnership(dataModuleAppManagerAddress);
     }
 
     /**
@@ -25,9 +27,9 @@ contract PauseRules is IPauseRules, DataModule {
      * @param _pauseStart pause window start timestamp
      * @param _pauseStop pause window stop timestamp
      */
-    function addPauseRule(uint256 _pauseStart, uint256 _pauseStop) public onlyOwner {
-        if(pauseRules.length >= 15) revert MaxPauseRulesReached();
-        
+    function addPauseRule(uint256 _pauseStart, uint256 _pauseStop) public virtual onlyOwner {
+        if (pauseRules.length >= 15) revert MaxPauseRulesReached();
+
         cleanOutdatedRules();
         if (_pauseStop <= _pauseStart || _pauseStart <= block.timestamp) {
             revert InvalidDateWindow(_pauseStart, _pauseStop);
@@ -52,7 +54,7 @@ contract PauseRules is IPauseRules, DataModule {
      * @param _pauseStart pause window start timestamp
      * @param _pauseStop pause window stop timestamp
      */
-    function removePauseRule(uint256 _pauseStart, uint256 _pauseStop) external onlyOwner {
+    function removePauseRule(uint256 _pauseStart, uint256 _pauseStop) external virtual onlyOwner {
         uint256 i;
         while (i < pauseRules.length) {
             bool exit;
@@ -74,7 +76,7 @@ contract PauseRules is IPauseRules, DataModule {
     /**
      * @dev Cleans up outdated pause rules by removing them from the mapping
      */
-    function cleanOutdatedRules() public {
+    function cleanOutdatedRules() public virtual {
         uint256 i;
         while (i < pauseRules.length) {
             while (pauseRules.length > 0 && i < pauseRules.length && pauseRules[i].pauseStop <= block.timestamp) {
@@ -91,7 +93,7 @@ contract PauseRules is IPauseRules, DataModule {
      * @dev Get the pauseRules data for a given tokenName.
      * @return pauseRules all the pause rules for the token
      */
-    function getPauseRules() external view onlyOwner returns (PauseRule[] memory) {
+    function getPauseRules() external view virtual onlyOwner returns (PauseRule[] memory) {
         return (pauseRules);
     }
 }

--- a/src/data/RiskScores.sol
+++ b/src/data/RiskScores.sol
@@ -11,14 +11,15 @@ import "./IRiskScores.sol";
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
 contract RiskScores is IRiskScores, DataModule {
-
     mapping(address => uint8) public scores;
 
     /**
      * @dev Constructor that sets the app manager address used for permissions. This is required for upgrades.
+     * @param _dataModuleAppManagerAddress address of the owning app manager
      */
-    constructor() {
-        dataModuleAppManagerAddress = owner();
+    constructor(address _dataModuleAppManagerAddress) {
+        dataModuleAppManagerAddress = _dataModuleAppManagerAddress;
+        _transferOwnership(dataModuleAppManagerAddress);
     }
 
     /**
@@ -26,7 +27,7 @@ contract RiskScores is IRiskScores, DataModule {
      * @param _address address of the account
      * @param _score risk score (0-100)
      */
-    function addScore(address _address, uint8 _score) public onlyOwner {
+    function addScore(address _address, uint8 _score) public virtual onlyOwner {
         if (_score > 100) revert riskScoreOutOfRange(_score);
         scores[_address] = _score;
         emit RiskScoreAdded(_address, _score, block.timestamp);
@@ -37,7 +38,7 @@ contract RiskScores is IRiskScores, DataModule {
      * @param _accounts address array upon which to apply the Risk Score
      * @param _score Risk Score(0-100)
      */
-    function addRiskScoreToMultipleAccounts(address[] memory _accounts, uint8 _score) external onlyOwner {
+    function addRiskScoreToMultipleAccounts(address[] memory _accounts, uint8 _score) external virtual onlyOwner {
         if (_score > 100) revert riskScoreOutOfRange(_score);
         for (uint256 i; i < _accounts.length; ) {
             scores[_accounts[i]] = _score;
@@ -52,7 +53,7 @@ contract RiskScores is IRiskScores, DataModule {
      * @dev Remove the risk score for the account. Restricted to the owner
      * @param _account address of the account
      */
-    function removeScore(address _account) external onlyOwner {
+    function removeScore(address _account) external virtual onlyOwner {
         delete scores[_account];
         emit RiskScoreRemoved(_account, block.timestamp);
     }
@@ -61,7 +62,7 @@ contract RiskScores is IRiskScores, DataModule {
      * @dev Get the risk score for the account. Restricted to the owner
      * @param _account address of the account
      */
-    function getRiskScore(address _account) external view onlyOwner returns (uint8) {
+    function getRiskScore(address _account) external view virtual onlyOwner returns (uint8) {
         return scores[_account];
     }
 }

--- a/src/example/ApplicationERC721.sol
+++ b/src/example/ApplicationERC721.sol
@@ -14,7 +14,7 @@ import "openzeppelin-contracts/contracts/access/Ownable.sol";
  * Only one safeMint function can be used at a time. Comment out all other safeMint functions and variables used for that function.
  */
 
-contract ApplicationERC721 is ProtocolERC721, Ownable {
+contract ApplicationERC721 is ProtocolERC721 {
     /// Optional Function Variables and Errors. Uncomment these if using option functions:
     // using Counters for Counters.Counter;
     // Counters.Counter private _tokenIdCounter;

--- a/src/interfaces/IErrors.sol
+++ b/src/interfaces/IErrors.sol
@@ -150,7 +150,7 @@ interface IAssetHandlerErrors {
     error ZeroValueNotPermited();
 }
 
-interface IAppManagerUserErrors {
+interface IOwnershipErrors {
     error ConfirmerDoesNotMatchProposedAddress();
     error NoProposalHasBeenMade();
 }

--- a/src/interfaces/IErrors.sol
+++ b/src/interfaces/IErrors.sol
@@ -148,5 +148,9 @@ interface IAssetHandlerErrors {
     error CannotTurnOffAccessLevel0WithAccessLevelBalanceActive();
     error PeriodExceeds5Years();
     error ZeroValueNotPermited();
+}
+
+interface IAppManagerUserErrors {
     error ConfirmerDoesNotMatchProposedAddress();
+    error NoProposalHasBeenMade();
 }

--- a/src/interfaces/IErrors.sol
+++ b/src/interfaces/IErrors.sol
@@ -8,35 +8,35 @@ pragma solidity 0.8.17;
  * @notice All errors are declared in this file, and then inherited in contracts.
  */
 
-interface IERC721Errors{
+interface IERC721Errors {
     error MaxNFTTransferReached();
     error MinimumHoldTimePeriodNotReached();
 }
 
-interface IRuleProcessorErrors{
+interface IRuleProcessorErrors {
     error RuleDoesNotExist();
 }
 
-interface IAccessLevelErrors{
+interface IAccessLevelErrors {
     error BalanceExceedsAccessLevelAllowedLimit();
     error WithdrawalExceedsAccessLevelAllowedLimit();
     error NotAllowedForAccessLevel();
     error AccessLevelIsNotValid(uint8 accessLevel);
 }
 
-interface IPauseRuleErrors{
+interface IPauseRuleErrors {
     error ApplicationPaused(uint started, uint ends);
     error InvalidDateWindow(uint256 startDate, uint256 endDate);
     error MaxPauseRulesReached();
 }
 
-interface IRiskErrors{
+interface IRiskErrors {
     error MaxTxSizePerPeriodReached(uint8 riskScore, uint256 maxTxSize, uint8 hoursOfPeriod);
     error TransactionExceedsRiskScoreLimit();
     error BalanceExceedsRiskScoreLimit();
 }
 
-interface IERC20Errors{
+interface IERC20Errors {
     error BelowMinTransfer();
     error AddressIsRestricted();
     error AddressNotOnAllowedList();
@@ -44,22 +44,21 @@ interface IERC20Errors{
     error PurchasePercentageReached();
     error SellPercentageReached();
     error TransferExceedsMaxVolumeAllowed();
-    error TotalSupplyVolatilityLimitReached(); 
+    error TotalSupplyVolatilityLimitReached();
 }
 
-
-interface IMaxTagLimitError{
+interface IMaxTagLimitError {
     error MaxTagLimitReached();
 }
 
-interface ITagRuleErrors{
+interface ITagRuleErrors {
     error MaxBalanceExceeded();
     error BalanceBelowMin();
     error TxnInFreezeWindow();
     error TemporarySellRestriction();
 }
 
-interface IInputErrors{
+interface IInputErrors {
     error IndexOutOfRange();
     error WrongArrayOrder();
     error InputArraysSizesNotValid();
@@ -69,13 +68,13 @@ interface IInputErrors{
     error InvertedLimits();
 }
 
-interface IAppRuleInputErrors{
+interface IAppRuleInputErrors {
     error InvalidHourOfTheDay();
     error BalanceAmountsShouldHave5Levels(uint8 inputLevels);
     error WithdrawalAmountsShouldHave5Levels(uint8 inputLevels);
 }
 
-interface IRiskInputErrors{
+interface IRiskInputErrors {
     error RiskLevelCannotExceed99();
     error riskScoreOutOfRange(uint8 riskScore);
 }
@@ -85,18 +84,18 @@ interface ITagInputErrors {
     error TagAlreadyExists();
 }
 
-interface ITagRuleInputErrors{
+interface ITagRuleInputErrors {
     error DateInThePast(uint256 date);
     error StartTimeNotValid();
 }
 
-interface IAppAdministratorOnlyErrors{
+interface IAppAdministratorOnlyErrors {
     error AppManagerNotConnected();
     error NotAppAdministrator();
     error NotAppAdministratorOrOwner();
 }
 
-interface IAppManagerErrors{
+interface IAppManagerErrors {
     error PricingModuleNotConfigured(address _erc20PricingAddress, address nftPricingAddress);
     error NotAccessTierAdministrator(address _address);
     error NotRiskAdmin(address _address);
@@ -104,23 +103,22 @@ interface IAppManagerErrors{
     error NoAddressToRemove();
 }
 
-interface AMMCalculatorErrors{
+interface AMMCalculatorErrors {
     error AmountsAreZero();
     error InsufficientPoolDepth(uint256 pool, int256 attemptedWithdrawal);
 }
 
-interface AMMErrors{
+interface AMMErrors {
     error TokenInvalid(address);
     error AmountExceedsBalance(uint256);
     error TransferFailed();
 }
 
-interface NFTPricingErrors{
+interface NFTPricingErrors {
     error NotAnNFTContract(address nftContract);
 }
 
-
-interface IStakingErrors{
+interface IStakingErrors {
     error DepositFailed();
     error NotStakingEnough(uint256 minStake);
     error NotStakingForAnyTime();
@@ -130,26 +128,25 @@ interface IStakingErrors{
     error InvalidTimeUnit();
 }
 
-interface IERC721StakingErrors{
+interface IERC721StakingErrors {
     error TokenNotValidToStake();
     error TokenNotAvailableToWithdraw();
 }
 
-interface IProtocolERC20Errors{
+interface IProtocolERC20Errors {
     error ExceedingMaxSupply();
     error CallerNotAuthorizedToMint();
 }
 
-interface IZeroAddressError{
+interface IZeroAddressError {
     error ZeroAddress();
 }
 
-interface IAssetHandlerErrors{
+interface IAssetHandlerErrors {
     error PricingModuleNotConfigured(address _erc20PricingAddress, address nftPricingAddress);
     error actionCheckFailed();
     error CannotTurnOffAccessLevel0WithAccessLevelBalanceActive();
     error PeriodExceeds5Years();
     error ZeroValueNotPermited();
+    error ConfirmerDoesNotMatchProposedAddress();
 }
-
-

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -10,11 +10,13 @@ pragma solidity 0.8.17;
 
 interface IAppLevelEvents {
     ///AppManager
-    event HandlerConnected(address indexed handlerAddress, address indexed appManager); 
+    event HandlerConnected(address indexed handlerAddress, address indexed appManager);
     event RoleCheck(string contractName, string functionName, address checkedAddress, bytes32 checkedRole);
     event AppManagerDeployed(address indexed deployedAddress);
     event AppManagerDeployedForUpgrade(address indexed deployedAddress);
     event AppManagerUpgrade(address indexed deployedAddress, address replacedAddress);
+    event AppManagerDataUpgradeProposed(address indexed deployedAddress, address replacedAddress);
+    event DataContractsMigrated(address indexed ownerAddress);
     event RemoveFromRegistry(string contractName, address contractAddress);
     event RiskAdminAdded(address newAdmin);
     event RiskAdminRemoved(address removedAdmin);

--- a/src/token/ProtocolERC20.sol
+++ b/src/token/ProtocolERC20.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.17;
 
 import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-contracts/contracts/security/Pausable.sol";
-import "../economic/AppAdministratorOnly.sol";
-import "../application/IAppManager.sol";
-import "../../src/token/ProtocolERC20Handler.sol";
 import "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20FlashMint.sol";
-import {IApplicationEvents} from "../interfaces/IEvents.sol";
-import { IZeroAddressError, IProtocolERC20Errors } from "../interfaces/IErrors.sol";
+import "./ProtocolTokenCommon.sol";
+import "src/token/ProtocolERC20Handler.sol";
+import "src/economic/AppAdministratorOnly.sol";
+
+import {IProtocolERC20Errors} from "../interfaces/IErrors.sol";
 
 /**
  * @title ERC20 Base Contract
@@ -18,11 +18,9 @@ import { IZeroAddressError, IProtocolERC20Errors } from "../interfaces/IErrors.s
  * @notice This is the base contract for all protocol ERC20s
  * @dev The only thing to recognize is that flash minting is added but not allowed...yet
  */
-contract ProtocolERC20 is ERC20, ERC165, ERC20Burnable, ERC20FlashMint, Pausable, AppAdministratorOnly, IApplicationEvents, IZeroAddressError, IProtocolERC20Errors {
-    address public appManagerAddress;
+contract ProtocolERC20 is ERC20, ERC165, ERC20Burnable, ERC20FlashMint, Pausable, ProtocolTokenCommon, IProtocolERC20Errors {
     // address of the Handler
     ProtocolERC20Handler handler;
-    IAppManager appManager;
 
     /// Max supply should only be set once. Zero means infinite supply.
     uint256 MAX_SUPPLY;

--- a/src/token/ProtocolERC20Handler.sol
+++ b/src/token/ProtocolERC20Handler.sol
@@ -669,20 +669,28 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
     }
 
     /**
-     * @dev This function is used to migrate the data contracts to a new CoinHandler. Use with care because it changes ownership. They will no
-     * longer be accessible from the original CoinHandler
-     * @param _newOwner address of the new CoinHandler
+     * @dev This function is used to propose the new owner for data contracts.
+     * @param _newOwner address of the new AppManager
      */
-    function migrateDataContracts(address _newOwner) external appAdministratorOnly(appManagerAddress) {
-        fees.transferOwnership(_newOwner);
+    function proposeDataContractMigration(address _newOwner) external appAdministratorOnly(appManagerAddress) {
+        fees.proposeOwner(_newOwner);
     }
 
     /**
-     * @dev This function is used to connect data contracts from an old CoinHandler to the current CoinHandler.
-     * @param _oldHandlerAddress address of the old CoinHandler
+     * @dev This function is used to confirm this contract as the new owner for data contracts.
      */
-    function connectDataContracts(address _oldHandlerAddress) external appAdministratorOnly(appManagerAddress) {
+    function confirmDataContractMigration(address _oldHandlerAddress) external appAdministratorOnly(appManagerAddress) {
         ProtocolERC20Handler oldHandler = ProtocolERC20Handler(_oldHandlerAddress);
         fees = Fees(oldHandler.getFeesDataAddress());
+        fees.confirmOwner();
     }
+
+    // /**
+    //  * @dev This function is used to connect data contracts from an old CoinHandler to the current CoinHandler.
+    //  * @param _oldHandlerAddress address of the old CoinHandler
+    //  */
+    // function connectDataContracts(address _oldHandlerAddress) external appAdministratorOnly(appManagerAddress) {
+    //     ProtocolERC20Handler oldHandler = ProtocolERC20Handler(_oldHandlerAddress);
+    //     fees = Fees(oldHandler.getFeesDataAddress());
+    // }
 }

--- a/src/token/ProtocolERC721.sol
+++ b/src/token/ProtocolERC721.sol
@@ -174,4 +174,6 @@ contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, P
     function getHandlerAddress() external view returns (address) {
         return handlerAddress;
     }
+
+    function proposeOwner() external pure {}
 }

--- a/src/token/ProtocolERC721.sol
+++ b/src/token/ProtocolERC721.sol
@@ -7,11 +7,9 @@ import "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
 import "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
-import "src/application/IAppManager.sol";
+import "./ProtocolTokenCommon.sol";
 import "src/economic/AppAdministratorOnly.sol";
 import "src/token/IProtocolERC721Handler.sol";
-import {IApplicationEvents} from "../interfaces/IEvents.sol";
-import {IZeroAddressError} from "../interfaces/IErrors.sol";
 
 /**
  * @title ERC721 Base Contract
@@ -19,12 +17,10 @@ import {IZeroAddressError} from "../interfaces/IErrors.sol";
  * @notice This is the base contract for all protocol ERC721s
  */
 
-contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, Pausable, AppAdministratorOnly, IApplicationEvents, IZeroAddressError {
+contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, Pausable, ProtocolTokenCommon {
     using Counters for Counters.Counter;
-    address public appManagerAddress;
     address public handlerAddress;
     IProtocolERC721Handler handler;
-    IAppManager appManager;
     Counters.Counter private _tokenIdCounter;
 
     /// Base Contract URI
@@ -136,15 +132,6 @@ contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, P
     }
 
     /**
-     * @dev Function to set the appManagerAddress and connect to the new appManager
-     * @dev AppAdministratorOnly modifier uses appManagerAddress. Only Addresses asigned as AppAdministrator can call function.
-     */
-    function setAppManagerAddress(address _appManagerAddress) external appAdministratorOnly(appManagerAddress) {
-        appManagerAddress = _appManagerAddress;
-        appManager = IAppManager(_appManagerAddress);
-    }
-
-    /**
      * @dev Returns true if this contract implements the interface defined by
      * `interfaceId`. See the corresponding
      * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
@@ -174,6 +161,4 @@ contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, P
     function getHandlerAddress() external view returns (address) {
         return handlerAddress;
     }
-
-    function proposeOwner() external pure {}
 }

--- a/src/token/ProtocolERC721Handler.sol
+++ b/src/token/ProtocolERC721Handler.sol
@@ -721,17 +721,6 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
     }
 
     /**
-     * @dev This function is used to migrate the data contracts to a new CoinHandler. Use with care because it changes ownership. They will no
-     * longer be accessible from the original CoinHandler
-     * @param _newOwner address of the new CoinHandler
-     */
-    function migrateDataContracts(address _newOwner) external appAdministratorOrOwnerOnly(appManagerAddress) {
-        fees.transferOwnership(_newOwner);
-        /// Also transfer ownership of this contract to the new asset
-        transferPermissionOwnership(_newOwner, appManagerAddress);
-    }
-
-    /**
      * @dev This function is used to connect data contracts from an old CoinHandler to the current CoinHandler.
      * @param _oldHandlerAddress address of the old CoinHandler
      */

--- a/src/token/ProtocolERC721U.sol
+++ b/src/token/ProtocolERC721U.sol
@@ -10,10 +10,8 @@ import "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.s
 import "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "openzeppelin-contracts-upgradeable/contracts/utils/CountersUpgradeable.sol";
-import "src/economic/AppAdministratorOnlyU.sol";
 import "src/token/IProtocolERC721Handler.sol";
-import {IApplicationEvents} from "../interfaces/IEvents.sol";
-import {IZeroAddressError} from "../interfaces/IErrors.sol";
+import "src/token/ProtocolTokenCommonU.sol";
 
 /**
  * @title ERC721 Upgradeable Protocol Contract
@@ -28,13 +26,10 @@ contract ProtocolERC721U is
     ERC721BurnableUpgradeable,
     OwnableUpgradeable,
     UUPSUpgradeable,
-    AppAdministratorOnlyU,
-    IApplicationEvents,
-    PausableUpgradeable,
-    IZeroAddressError
+    ProtocolTokenCommonU,
+    PausableUpgradeable
 {
     using CountersUpgradeable for CountersUpgradeable.Counter;
-    address public appManagerAddress;
     address public handlerAddress;
     IProtocolERC721Handler handler;
     CountersUpgradeable.Counter private _tokenIdCounter;
@@ -147,14 +142,6 @@ contract ProtocolERC721U is
     function withdraw() public payable virtual appAdministratorOnly(appManagerAddress) {
         (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
         require(success);
-    }
-
-    /**
-     * @dev Function to set the appManagerAddress and connect to the new appManager
-     * @dev AppAdministratorOnly modifier uses appManagerAddress. Only Addresses asigned as AppAdministrator can call function.
-     */
-    function setAppManagerAddress(address _appManagerAddress) external appAdministratorOnly(appManagerAddress) {
-        appManagerAddress = _appManagerAddress;
     }
 
     /**

--- a/src/token/ProtocolERC721Umin.sol
+++ b/src/token/ProtocolERC721Umin.sol
@@ -3,18 +3,15 @@ pragma solidity 0.8.17;
 
 import "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import "src/economic/AppAdministratorOnlyU.sol";
 import "src/token/IProtocolERC721Handler.sol";
-import {IApplicationEvents} from "src/interfaces/IEvents.sol";
-import {IZeroAddressError} from "src/interfaces/IErrors.sol";
+import "src/token/ProtocolTokenCommonU.sol";
 
 /**
  * @title ERC721 Upgradeable Protocol Contract
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  * @notice This is the base contract for all protocol ERC721Upgradeables
  */
-contract ProtocolERC721Umin is Initializable, AppAdministratorOnlyU, IApplicationEvents, IZeroAddressError, ERC721EnumerableUpgradeable {
-    address private appManagerAddress;
+contract ProtocolERC721Umin is Initializable, ERC721EnumerableUpgradeable, ProtocolTokenCommonU {
     address private handlerAddress;
     IProtocolERC721Handler private handler;
 
@@ -46,22 +43,6 @@ contract ProtocolERC721Umin is Initializable, AppAdministratorOnlyU, IApplicatio
         // Rule Processor Module Check
         require(handler.checkAllRules(from == address(0) ? 0 : balanceOf(from), to == address(0) ? 0 : balanceOf(to), from, to, 1, tokenId, ActionTypes.TRADE));
         super._beforeTokenTransfer(from, to, tokenId, batchSize);
-    }
-
-    /**
-     * @dev Function to set the appManagerAddress
-     * @dev AppAdministratorOnly modifier uses appManagerAddress. Only Addresses asigned as AppAdministrator can call function.
-     */
-    function setAppManagerAddress(address _appManagerAddress) external appAdministratorOnly(appManagerAddress) {
-        appManagerAddress = _appManagerAddress;
-    }
-
-    /**
-     * @dev Function to get the appManagerAddress
-     * @dev AppAdministratorOnly modifier uses appManagerAddress. Only Addresses asigned as AppAdministrator can call function.
-     */
-    function getAppManagerAddress() external view returns (address) {
-        return appManagerAddress;
     }
 
     /**

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import {IAssetHandlerErrors, IAppManagerUserErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
+import {IAssetHandlerErrors, IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 import {ITokenHandlerEvents} from "../interfaces/IEvents.sol";
 import "src/economic/ruleStorage/RuleCodeData.sol";
 import "src/economic/IRuleProcessor.sol";
@@ -20,7 +20,7 @@ import "src/application/IAppManagerUser.sol";
  * @notice This contract contains common variables and functions for all Protocol Asset Handlers
  */
 
-contract ProtocolHandlerCommon is IAppManagerUser, IAppManagerUserErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
+contract ProtocolHandlerCommon is IAppManagerUser, IOwnershipErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
     address private newAppManagerAddress;
     address public appManagerAddress;
     IRuleProcessor ruleProcessor;

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {IAssetHandlerErrors} from "../interfaces/IErrors.sol";
+import {ITokenHandlerEvents} from "../interfaces/IEvents.sol";
+import "src/economic/ruleStorage/RuleCodeData.sol";
+import "src/economic/IRuleProcessor.sol";
+import "src/application/IAppManager.sol";
+import "src/pricing/IProtocolERC721Pricing.sol";
+import "src/pricing/IProtocolERC20Pricing.sol";
+import "src/economic/AppAdministratorOrOwnerOnly.sol";
+import "src/economic/AppAdministratorOnly.sol";
+
+/**
+ * @title Protocol Handler Common
+ * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
+ * @notice This contract contains common variables and functions for all Protocol Asset Handlers
+ */
+
+contract ProtocolHandlerCommon is IAssetHandlerErrors, ITokenHandlerEvents, AppAdministratorOrOwnerOnly {
+    address private newAppManagerAddress;
+    address public appManagerAddress;
+    IRuleProcessor ruleProcessor;
+    IAppManager appManager;
+    // Pricing Module interfaces
+    IProtocolERC20Pricing erc20Pricer;
+    IProtocolERC721Pricing nftPricer;
+    address public erc20PricingAddress;
+    address public nftPricingAddress;
+
+    /**
+     * @dev this function proposes a new appManagerAddress that is put in storage to be confirmed in a separate process
+     * @param _newAppManagerAddress the new address being proposed
+     */
+    function proposeAppManagerAddress(address _newAppManagerAddress) external {
+        newAppManagerAddress = _newAppManagerAddress;
+    }
+
+    /**
+     * @dev this function confirms a new appManagerAddress that was put in storageIt can only be confirmed by the proposed address
+     */
+    function confirmAppManagerAddress() external {
+        if (msg.sender != newAppManagerAddress) revert ConfirmerDoesNotMatchProposedAddress();
+        appManagerAddress = newAppManagerAddress;
+        appManager = IAppManager(appManagerAddress);
+        delete newAppManagerAddress;
+    }
+
+    /**
+     * @dev sets the address of the nft pricing contract and loads the contract.
+     * @param _address Nft Pricing Contract address.
+     */
+    function setNFTPricingAddress(address _address) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        nftPricingAddress = _address;
+        nftPricer = IProtocolERC721Pricing(_address);
+    }
+
+    /**
+     * @dev sets the address of the erc20 pricing contract and loads the contract.
+     * @param _address ERC20 Pricing Contract address.
+     */
+    function setERC20PricingAddress(address _address) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        erc20PricingAddress = _address;
+        erc20Pricer = IProtocolERC20Pricing(_address);
+    }
+
+    /**
+     * @dev Get the account's balance in dollars. It uses the registered tokens in the app manager.
+     * @notice This gets the account's balance in dollars.
+     * @param _account address to get the balance for
+     * @return totalValuation of the account in dollars
+     */
+    function getAccTotalValuation(address _account) internal view returns (uint256 totalValuation) {
+        address[] memory tokenList = appManager.getTokenList();
+        uint256 tokenAmount;
+        /// Loop through all Nfts and ERC20s and add values to balance
+        for (uint256 i; i < tokenList.length; ) {
+            /// First check to see if user owns the asset
+            tokenAmount = (IToken(tokenList[i]).balanceOf(_account));
+
+            if (tokenAmount > 0) {
+                try IERC165(tokenList[i]).supportsInterface(0x80ac58cd) returns (bool isERC721) {
+                    if (isERC721) totalValuation += _getNFTValuePerCollection(tokenList[i], _account, tokenAmount);
+                    else {
+                        uint8 decimals = ERC20(tokenList[i]).decimals();
+                        totalValuation += (_getERC20Price(tokenList[i]) * (tokenAmount)) / (10 ** decimals);
+                    }
+                } catch {
+                    uint8 decimals = ERC20(tokenList[i]).decimals();
+                    totalValuation += (_getERC20Price(tokenList[i]) * (tokenAmount)) / (10 ** decimals);
+                }
+            }
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /**
+     * @dev Get the value for a specific ERC20. This is done by interacting with the pricing module
+     * @notice This gets the token's value in dollars.
+     * @param _tokenAddress the address of the token
+     * @return price the price of 1 in dollars
+     */
+    function _getERC20Price(address _tokenAddress) internal view returns (uint256) {
+        if (erc20PricingAddress != address(0)) {
+            return erc20Pricer.getTokenPrice(_tokenAddress);
+        } else {
+            revert PricingModuleNotConfigured(erc20PricingAddress, nftPricingAddress);
+        }
+    }
+
+    /**
+     * @dev Get the value for a specific ERC721. This is done by interacting with the pricing module
+     * @notice This gets the token's value in dollars.
+     * @param _tokenAddress the address of the token
+     * @param _account of the token holder
+     * @param _tokenAmount amount of NFTs from _tokenAddress contract
+     * @return totalValueInThisContract in whole USD
+     */
+    function _getNFTValuePerCollection(address _tokenAddress, address _account, uint256 _tokenAmount) internal view returns (uint256 totalValueInThisContract) {
+        if (nftPricingAddress != address(0)) {
+            for (uint i; i < _tokenAmount; ) {
+                totalValueInThisContract += nftPricer.getNFTPrice(_tokenAddress, IERC721Enumerable(_tokenAddress).tokenOfOwnerByIndex(_account, i));
+                unchecked {
+                    ++i;
+                }
+            }
+        } else {
+            revert PricingModuleNotConfigured(erc20PricingAddress, nftPricingAddress);
+        }
+    }
+}
+
+interface IToken {
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    function totalSupply() external view returns (uint256);
+
+    function decimals() external view returns (uint8);
+}

--- a/src/token/ProtocolTokenCommon.sol
+++ b/src/token/ProtocolTokenCommon.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "src/economic/AppAdministratorOnly.sol";
+import {IApplicationEvents} from "../interfaces/IEvents.sol";
+import {IZeroAddressError} from "../interfaces/IErrors.sol";
+
+/**
+ * @title Protocol Token Common Contract
+ * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
+ * @notice This contract contains common variables and functions for all Protocol Tokens
+ */
+
+contract ProtocolTokenCommon is AppAdministratorOnly, IApplicationEvents, IZeroAddressError {
+    address public appManagerAddress;
+    IAppManager appManager;
+
+    /**
+     * @dev Function to set the appManagerAddress and connect to the new appManager
+     * @dev AppAdministratorOnly modifier uses appManagerAddress. Only Addresses asigned as AppAdministrator can call function.
+     */
+    function setAppManagerAddress(address _appManagerAddress) external appAdministratorOnly(appManagerAddress) {
+        appManagerAddress = _appManagerAddress;
+        appManager = IAppManager(_appManagerAddress);
+    }
+}

--- a/src/token/ProtocolTokenCommon.sol
+++ b/src/token/ProtocolTokenCommon.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "src/economic/AppAdministratorOnly.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
-import {IAppManagerUserErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
+import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 
 /**
  * @title Protocol Token Common Contract
@@ -11,7 +11,7 @@ import {IAppManagerUserErrors, IZeroAddressError} from "../interfaces/IErrors.so
  * @notice This contract contains common variables and functions for all Protocol Tokens
  */
 
-contract ProtocolTokenCommon is AppAdministratorOnly, IApplicationEvents, IZeroAddressError, IAppManagerUserErrors {
+contract ProtocolTokenCommon is AppAdministratorOnly, IApplicationEvents, IZeroAddressError, IOwnershipErrors {
     address private newAppManagerAddress;
     address public appManagerAddress;
     IAppManager appManager;

--- a/src/token/ProtocolTokenCommonU.sol
+++ b/src/token/ProtocolTokenCommonU.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "src/economic/AppAdministratorOnly.sol";
+import "src/economic/AppAdministratorOnlyU.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 
@@ -11,7 +11,7 @@ import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
  * @notice This contract contains common variables and functions for all Protocol Tokens
  */
 
-contract ProtocolTokenCommon is AppAdministratorOnly, IApplicationEvents, IZeroAddressError, IOwnershipErrors {
+contract ProtocolTokenCommonU is AppAdministratorOnlyU, IApplicationEvents, IZeroAddressError, IOwnershipErrors {
     address newAppManagerAddress;
     address appManagerAddress;
     IAppManager appManager;

--- a/src/token/data/Fees.sol
+++ b/src/token/data/Fees.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.17;
 import "openzeppelin-contracts/contracts/access/Ownable.sol";
 import {IApplicationEvents} from "../../interfaces/IEvents.sol";
-import {IInputErrors, ITagInputErrors} from "../../interfaces/IErrors.sol";
+import {IInputErrors, ITagInputErrors, IOwnershipErrors, IZeroAddressError} from "../../interfaces/IErrors.sol";
+import "src/economic/AppAdministratorOnly.sol";
 
 /**
  * @title Fees
@@ -10,10 +11,11 @@ import {IInputErrors, ITagInputErrors} from "../../interfaces/IErrors.sol";
  * @dev This contract should not be accessed directly. All processing should go through its controlling asset(ProtocolERC20, ProtocolERC721, etc.)
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
-contract Fees is Ownable, IApplicationEvents, IInputErrors, ITagInputErrors{
+contract Fees is Ownable, IApplicationEvents, IInputErrors, ITagInputErrors, IOwnershipErrors, IZeroAddressError, AppAdministratorOnly {
     int256 defaultFee;
     mapping(bytes32 => Fee) feesByTag;
     uint256 feeTotal;
+    address newOwner; // This is used for data contract migration
     struct Fee {
         uint256 minBalance;
         uint256 maxBalance;
@@ -21,6 +23,7 @@ contract Fees is Ownable, IApplicationEvents, IInputErrors, ITagInputErrors{
         address feeCollectorAccount;
         bool isValue; // this is just for housekeeping purposes
     }
+
     /**
      * @dev This function adds a fee to the token
      * @param _tag meta data tag for fee
@@ -75,5 +78,23 @@ contract Fees is Ownable, IApplicationEvents, IInputErrors, ITagInputErrors{
      */
     function getFeeTotal() external view onlyOwner returns (uint256) {
         return feeTotal;
+    }
+
+    /**
+     * @dev this function proposes a new owner that is put in storage to be confirmed in a separate process
+     * @param _newOwner the new address being proposed
+     */
+    function proposeOwner(address _newOwner) external onlyOwner {
+        if (_newOwner == address(0)) revert ZeroAddress();
+        newOwner = _newOwner;
+    }
+
+    /**
+     * @dev this function confirms a new asset handler address that was put in storage. It can only be confirmed by the proposed address
+     */
+    function confirmOwner() external {
+        if (newOwner == address(0)) revert NoProposalHasBeenMade();
+        if (msg.sender != newOwner) revert ConfirmerDoesNotMatchProposedAddress();
+        _transferOwnership(newOwner);
     }
 }

--- a/test/ApplicationAppManager.t.sol
+++ b/test/ApplicationAppManager.t.sol
@@ -652,14 +652,6 @@ contract ApplicationAppManagerTest is DiamondTestUtil, RuleProcessorDiamondTestU
         assertFalse(applicationAppManager.hasTag(user, "TAG1"));
     }
 
-    ///---------------AccessLevel PROVIDER---------------
-    // Test setting access levelprovider contract address
-    function testAccessLevelProviderSet() public {
-        switchToAppAdministrator(); // create a app administrator and make it the sender.
-        applicationAppManager.setAccessLevelProvider(address(88));
-        assertEq(address(88), applicationAppManager.getAccessLevelProvider());
-    }
-
     /// Test the register token.
     function testRegisterToken() public {
         applicationAppManager.registerToken("Frankenstein", address(77));

--- a/test/ApplicationAppManagerFuzz.t.sol
+++ b/test/ApplicationAppManagerFuzz.t.sol
@@ -542,26 +542,6 @@ contract ApplicationAppManagerFuzzTest is DiamondTestUtil, RuleProcessorDiamondT
         }
     }
 
-    ///---------------AccessLevel PROVIDER---------------
-    // Test setting access levelprovider contract address
-    function testAccessLevelProviderSet(uint8 addressIndexA, uint8 addressIndexB, address provider) public {
-        vm.stopPrank();
-        vm.assume(provider != address(0));
-        address sender = ADDRESSES[addressIndexA % ADDRESSES.length];
-        address admin = ADDRESSES[addressIndexB % ADDRESSES.length];
-        vm.startPrank(sender);
-        if (sender != defaultAdmin) vm.expectRevert();
-        appManager.setAccessLevelProvider(provider);
-        if (sender == defaultAdmin) {
-            assertEq(provider, appManager.getAccessLevelProvider());
-            vm.stopPrank();
-            vm.startPrank(admin);
-            if (admin != defaultAdmin) vm.expectRevert();
-            appManager.setAccessLevelProvider(address(0xBABE));
-            if (admin == defaultAdmin) assertEq(address(0xBABE), appManager.getAccessLevelProvider());
-        }
-    }
-
     /**
      * ################# TEST DIFFERENT SCENARIOS #####################
      */

--- a/test/ApplicationERC20Handler.t.sol
+++ b/test/ApplicationERC20Handler.t.sol
@@ -447,10 +447,10 @@ contract ApplicationERC20HandlerTest is Test, DiamondTestUtil, RuleProcessorDiam
 
         /// create new handler
         ApplicationERC20Handler applicationCoinHandlerNew = new ApplicationERC20Handler(address(ruleProcessor), ac, false);
-        /// migrate data contracts to new handler
-        applicationCoinHandler.migrateDataContracts(address(applicationCoinHandlerNew));
         /// connect the old data contract to the new handler
-        applicationCoinHandlerNew.connectDataContracts(address(applicationCoinHandler));
+        applicationCoinHandler.proposeDataContractMigration(address(applicationCoinHandlerNew));
+        applicationCoinHandlerNew.confirmDataContractMigration(address(applicationCoinHandler));
+
         /// test that the data is accessible only from the new handler
         fee = applicationCoinHandlerNew.getFee(tag1);
         assertEq(fee.feePercentage, feePercentage);
@@ -461,10 +461,10 @@ contract ApplicationERC20HandlerTest is Test, DiamondTestUtil, RuleProcessorDiam
         vm.stopPrank();
         vm.startPrank(user1);
         vm.expectRevert(0xba80c9e5);
-        applicationCoinHandlerNew.migrateDataContracts(address(applicationCoinHandler));
+        applicationCoinHandlerNew.proposeDataContractMigration(address(applicationCoinHandler));
 
         vm.stopPrank();
         vm.startPrank(appAdministrator);
-        applicationCoinHandlerNew.migrateDataContracts(address(applicationCoinHandler));
+        applicationCoinHandlerNew.proposeDataContractMigration(address(applicationCoinHandler));
     }
 }

--- a/test/ApplicationERC721U.t.sol
+++ b/test/ApplicationERC721U.t.sol
@@ -727,6 +727,40 @@ contract ApplicationERC721UTest is DiamondTestUtil, RuleProcessorDiamondTestUtil
         applicationNFTHandler.setAdminWithdrawalRuleId(1);
     }
 
+    function testUpgradeAppManager721u() public {
+        address newAdmin = address(75);
+        /// create a new app manager
+        ApplicationAppManager appManager2 = new ApplicationAppManager(newAdmin, "Castlevania2", false);
+        /// propose a new AppManager
+        ApplicationERC721U(address(applicationNFTProxy)).proposeAppManagerAddress(address(appManager2));
+        /// confirm the app manager
+        vm.stopPrank();
+        vm.startPrank(newAdmin);
+        appManager2.confirmAppManager(address(applicationNFTProxy));
+        /// test to ensure it still works
+        ApplicationERC721U(address(applicationNFTProxy)).safeMint(defaultAdmin);
+        vm.stopPrank();
+        vm.startPrank(defaultAdmin);
+        ApplicationERC721U(address(applicationNFTProxy)).transferFrom(defaultAdmin, appAdministrator, 0);
+        assertEq(ApplicationERC721U(address(applicationNFTProxy)).balanceOf(defaultAdmin), 0);
+        assertEq(ApplicationERC721U(address(applicationNFTProxy)).balanceOf(appAdministrator), 1);
+
+        /// Test fail scenarios
+        vm.stopPrank();
+        vm.startPrank(newAdmin);
+        // zero address
+        vm.expectRevert(0xd92e233d);
+        ApplicationERC721U(address(applicationNFTProxy)).proposeAppManagerAddress(address(0));
+        // no proposed address
+        vm.expectRevert(0x821e0eeb);
+        appManager2.confirmAppManager(address(applicationNFT));
+        // non proposer tries to confirm
+        ApplicationERC721U(address(applicationNFTProxy)).proposeAppManagerAddress(address(appManager2));
+        ApplicationAppManager appManager3 = new ApplicationAppManager(newAdmin, "Castlevania3", false);
+        vm.expectRevert(0x41284967);
+        appManager3.confirmAppManager(address(applicationNFTProxy));
+    }
+
     function testUpgradingHandlersUpgradeable() public {
         ///deploy new modified appliction asset handler contract
         ApplicationERC721HandlerMod assetHandler = new ApplicationERC721HandlerMod(address(ruleProcessor), address(appManager), true);


### PR DESCRIPTION
Recommendations
Short term, implement a two-step process for all irrecoverable critical operations. Split all
functions that set contracts owners and administrators into two functions:
1. proposeOwner() or proposeAppManagerAddress() which proposes a new contract
owner or manager which is saved in the contract storage,
2. confirmOwner() or confirmAppManagerAddress() which can only be called by the
proposed owner or manager and is used to finalize the transfer

This will guarantee that the owner-setting party must be able to call the contract from the
address in question before it is actually set as the new owner.