### PR TITLE
Audit 23,  Multiple functions return an empty rule instead of reverting

### DIFF
--- a/script/Deploy_02_ProcessorDiamond.s.sol
+++ b/script/Deploy_02_ProcessorDiamond.s.sol
@@ -58,7 +58,7 @@ contract DeployAllModulesScript is Script {
         DiamondInit diamondInit = new DiamondInit();
 
         /// Register all facets.
-        string[11] memory facets = [
+        string[12] memory facets = [
             /// Native facets,
             "ProtocolNativeFacet",
             /// Raw implementation facets.
@@ -73,7 +73,8 @@ contract DeployAllModulesScript is Script {
             "ApplicationPauseProcessorFacet",
             "ERC20TaggedRuleProcessorFacet",
             "ERC721TaggedRuleProcessorFacet",
-            "RiskTaggedRuleProcessorFacet"
+            "RiskTaggedRuleProcessorFacet",
+            "RuleApplicationValidationFacet"
         ];
 
         string[] memory inputs = new string[](3);

--- a/src/application/ProtocolApplicationHandler.sol
+++ b/src/application/ProtocolApplicationHandler.sol
@@ -144,6 +144,7 @@ contract ProtocolApplicationHandler is Ownable, AppAdministratorOnly, IApplicati
      * @param _ruleId Rule Id to set
      */
     function setAccountBalanceByRiskRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateAccBalanceByRisk(_ruleId);
         accountBalanceByRiskRuleId = _ruleId;
         accountBalanceByRiskRuleActive = true;
         emit ApplicationRuleApplied(BALANCE_BY_RISK, _ruleId);
@@ -230,6 +231,7 @@ contract ProtocolApplicationHandler is Ownable, AppAdministratorOnly, IApplicati
      * @param _ruleId Rule Id to set
      */
     function setWithdrawalLimitByAccessLevelRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateWithdrawalLimitsByAccessLevel(_ruleId);
         withdrawalLimitByAccessLevelRuleId = _ruleId;
         withdrawalLimitByAccessLevelRuleActive = true;
         emit ApplicationRuleApplied(ACCESS_LEVEL_WITHDRAWAL, _ruleId);
@@ -273,6 +275,7 @@ contract ProtocolApplicationHandler is Ownable, AppAdministratorOnly, IApplicati
      * @param _ruleId Rule Id to set
      */
     function setMaxTxSizePerPeriodByRiskRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateMaxTxSizePerPeriodByRisk(_ruleId);
         maxTxSizePerPeriodByRiskRuleId = _ruleId;
         maxTxSizePerPeriodByRiskActive = true;
         emit ApplicationRuleApplied(MAX_TX_PER_PERIOD, _ruleId);

--- a/src/economic/IRuleProcessor.sol
+++ b/src/economic/IRuleProcessor.sol
@@ -247,14 +247,21 @@ interface IRuleProcessor {
     /**
      * @dev Rule checks if the total supply volatility rule will be violated.
      * @param _ruleId Rule identifier for rule arguments
-     * @param _volumeTotalForPeriod token's increase/decreased volume total in period 
+     * @param _volumeTotalForPeriod token's increase/decreased volume total in period
      * @param _totalSupplyForPeriod token total supply updated at begining of period
      * @param _amount Number of tokens to be minted/burned
      * @param _supply Number of tokens in supply
      * @param _lastSupplyUpdateTime the time of the last transfer
      * @return volumeTotal new accumulated volume
      */
-    function checkTotalSupplyVolatilityPasses(uint32 _ruleId, int256 _volumeTotalForPeriod, uint256 _totalSupplyForPeriod, uint256 _supply, int256 _amount, uint64 _lastSupplyUpdateTime) external view returns (int256, uint256);
+    function checkTotalSupplyVolatilityPasses(
+        uint32 _ruleId,
+        int256 _volumeTotalForPeriod,
+        uint256 _totalSupplyForPeriod,
+        uint256 _supply,
+        int256 _amount,
+        uint64 _lastSupplyUpdateTime
+    ) external view returns (int256, uint256);
 
     /**
      * @dev This function receives data needed to check Minimum hold time rule. This a simple rule and thus is not stored in the rule storage diamond.
@@ -262,4 +269,126 @@ interface IRuleProcessor {
      * @param _ownershipTs beginning of hold period
      */
     function checkNFTHoldTime(uint32 _holdHours, uint256 _ownershipTs) external view;
+
+    /* ---------------------------- Rule Validation Functions --------------------------------- */
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAMMFee(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateTransactionLimitByRiskScore(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinMaxAccountBalanceERC721(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateNFTTransferCounter(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinMaxAccountBalance(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validatePurchaseLimit(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateSellLimit(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAdminWithdrawal(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinBalByDate(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinTransfer(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateOracle(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validatePurchasePercentage(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateSellPercentage(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateTokenTransferVolume(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateSupplyVolatility(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAccBalanceByRisk(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMaxTxSizePerPeriodByRisk(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     * @param _dataServer address of the appManager contract
+     */
+    function validatePause(uint32 _ruleId, address _dataServer) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAccBalanceByAccessLevel(uint32 _ruleId) external view;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateWithdrawalLimitsByAccessLevel(uint32 _ruleId) external view;
 }

--- a/src/economic/ruleProcessor/ApplicationRiskProcessorFacet.sol
+++ b/src/economic/ruleProcessor/ApplicationRiskProcessorFacet.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.17;
 import {RuleProcessorDiamondLib as actionDiamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
 import {AppRuleDataFacet} from "src/economic/ruleStorage/AppRuleDataFacet.sol";
 import {IApplicationRules as ApplicationRuleStorage} from "src/economic/ruleStorage/RuleDataInterfaces.sol";
-import {IRuleProcessorErrors, IRiskErrors} from "../../interfaces/IErrors.sol";
+import {IRuleProcessorErrors, IRiskErrors} from "src/interfaces/IErrors.sol";
 
 /**
  * @title Risk Score Processor Facet Contract
@@ -14,8 +14,6 @@ import {IRuleProcessorErrors, IRiskErrors} from "../../interfaces/IErrors.sol";
  * in terms of USD with 18 decimals of precision.
  */
 contract ApplicationRiskProcessorFacet is IRuleProcessorErrors, IRiskErrors {
-    
-
     /**
      * @dev Account balance by Risk Score
      * @param _ruleId Rule Identifier for rule arguments

--- a/src/economic/ruleProcessor/RuleApplicationValidationFacet.sol
+++ b/src/economic/ruleProcessor/RuleApplicationValidationFacet.sol
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import {RuleProcessorDiamondLib as Diamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
+import {FeeRuleDataFacet} from "src/economic/ruleStorage/FeeRuleDataFacet.sol";
+import {TaggedRuleDataFacet} from "src/economic/ruleStorage/TaggedRuleDataFacet.sol";
+import {RuleDataFacet} from "src/economic/ruleStorage/RuleDataFacet.sol";
+import {AppRuleDataFacet} from "src/economic/ruleStorage/AppRuleDataFacet.sol";
+import {IFeeRules as Fee, ITaggedRules as TaggedRules, INonTaggedRules as NonTaggedRules} from "../ruleStorage/RuleDataInterfaces.sol";
+import "src/economic/ruleStorage/RuleStorageCommonLib.sol";
+import "src/data/PauseRule.sol";
+import "src/application/IAppManager.sol";
+import "forge-std/console.sol";
+
+/**
+ * @title Fee Rule Processor Facet Contract
+ * @author @ShaneDuncan602 @oscarsernarosero @TJ-Everett
+ * @dev Facet in charge of the logic to check fee rule compliance
+ * @notice Implements Token Fee Rules on Accounts.
+ */
+contract RuleApplicationValidationFacet {
+    using RuleStorageCommonLib for uint32;
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAMMFee(uint32 _ruleId) external view {
+        FeeRuleDataFacet data = FeeRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalAMMFeeRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateTransactionLimitByRiskScore(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalTransactionLimitByRiskRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinMaxAccountBalanceERC721(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalBalanceLimitRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateNFTTransferCounter(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalNFTTransferCounterRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinMaxAccountBalance(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalBalanceLimitRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validatePurchaseLimit(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalPurchaseRule());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateSellLimit(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalSellRule());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAdminWithdrawal(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalAdminWithdrawalRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinBalByDate(uint32 _ruleId) external view {
+        TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalMinBalByDateRule());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMinTransfer(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        console.log("validateMinBalByDate _ruleId", _ruleId);
+        console.log("getTotalMinimumTransferRules", data.getTotalMinimumTransferRules());
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalMinimumTransferRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateOracle(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalOracleRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validatePurchasePercentage(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalPctPurchaseRule());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateSellPercentage(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalPctSellRule());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateTokenTransferVolume(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalTransferVolumeRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateSupplyVolatility(uint32 _ruleId) external view {
+        RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalSupplyVolatilityRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAccBalanceByRisk(uint32 _ruleId) external view {
+        AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalAccountBalanceByRiskScoreRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateMaxTxSizePerPeriodByRisk(uint32 _ruleId) external view {
+        AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalMaxTxSizePerPeriodRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     * @param _dataServer address of the appManager contract
+     */
+    function validatePause(uint32 _ruleId, address _dataServer) external view {
+        PauseRule[] memory pauseRules = IAppManager(_dataServer).getPauseRules();
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(uint32(pauseRules.length));
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateAccBalanceByAccessLevel(uint32 _ruleId) external view {
+        AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalAccessLevelBalanceRules());
+    }
+
+    /**
+     * @dev Validate the existence of the rule
+     * @param _ruleId Rule Identifier
+     */
+    function validateWithdrawalLimitsByAccessLevel(uint32 _ruleId) external view {
+        AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
+        // check one of the required non zero values to check for existence, if not, revert
+        _ruleId.checkRuleExistence(data.getTotalAccessLevelWithdrawalRules());
+    }
+}

--- a/src/economic/ruleProcessor/RuleApplicationValidationFacet.sol
+++ b/src/economic/ruleProcessor/RuleApplicationValidationFacet.sol
@@ -27,7 +27,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateAMMFee(uint32 _ruleId) external view {
         FeeRuleDataFacet data = FeeRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalAMMFeeRules());
     }
 
@@ -37,7 +37,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateTransactionLimitByRiskScore(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalTransactionLimitByRiskRules());
     }
 
@@ -47,7 +47,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateMinMaxAccountBalanceERC721(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalBalanceLimitRules());
     }
 
@@ -57,7 +57,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateNFTTransferCounter(uint32 _ruleId) external view {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalNFTTransferCounterRules());
     }
 
@@ -67,7 +67,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateMinMaxAccountBalance(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalBalanceLimitRules());
     }
 
@@ -77,7 +77,7 @@ contract RuleApplicationValidationFacet {
      */
     function validatePurchaseLimit(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalPurchaseRule());
     }
 
@@ -87,7 +87,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateSellLimit(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalSellRule());
     }
 
@@ -97,7 +97,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateAdminWithdrawal(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalAdminWithdrawalRules());
     }
 
@@ -107,7 +107,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateMinBalByDate(uint32 _ruleId) external view {
         TaggedRuleDataFacet data = TaggedRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalMinBalByDateRule());
     }
 
@@ -119,7 +119,7 @@ contract RuleApplicationValidationFacet {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
         console.log("validateMinBalByDate _ruleId", _ruleId);
         console.log("getTotalMinimumTransferRules", data.getTotalMinimumTransferRules());
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalMinimumTransferRules());
     }
 
@@ -129,7 +129,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateOracle(uint32 _ruleId) external view {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalOracleRules());
     }
 
@@ -139,7 +139,7 @@ contract RuleApplicationValidationFacet {
      */
     function validatePurchasePercentage(uint32 _ruleId) external view {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalPctPurchaseRule());
     }
 
@@ -149,7 +149,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateSellPercentage(uint32 _ruleId) external view {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalPctSellRule());
     }
 
@@ -159,7 +159,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateTokenTransferVolume(uint32 _ruleId) external view {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalTransferVolumeRules());
     }
 
@@ -169,7 +169,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateSupplyVolatility(uint32 _ruleId) external view {
         RuleDataFacet data = RuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalSupplyVolatilityRules());
     }
 
@@ -179,7 +179,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateAccBalanceByRisk(uint32 _ruleId) external view {
         AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalAccountBalanceByRiskScoreRules());
     }
 
@@ -189,7 +189,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateMaxTxSizePerPeriodByRisk(uint32 _ruleId) external view {
         AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalMaxTxSizePerPeriodRules());
     }
 
@@ -200,7 +200,7 @@ contract RuleApplicationValidationFacet {
      */
     function validatePause(uint32 _ruleId, address _dataServer) external view {
         PauseRule[] memory pauseRules = IAppManager(_dataServer).getPauseRules();
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(uint32(pauseRules.length));
     }
 
@@ -210,7 +210,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateAccBalanceByAccessLevel(uint32 _ruleId) external view {
         AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalAccessLevelBalanceRules());
     }
 
@@ -220,7 +220,7 @@ contract RuleApplicationValidationFacet {
      */
     function validateWithdrawalLimitsByAccessLevel(uint32 _ruleId) external view {
         AppRuleDataFacet data = AppRuleDataFacet(Diamond.ruleDataStorage().rules);
-        // check one of the required non zero values to check for existence, if not, revert
+        // Check to make sure the rule exists within rule storage
         _ruleId.checkRuleExistence(data.getTotalAccessLevelWithdrawalRules());
     }
 }

--- a/src/economic/ruleProcessor/RuleProcessorCommonLib.sol
+++ b/src/economic/ruleProcessor/RuleProcessorCommonLib.sol
@@ -10,15 +10,6 @@ library RuleProcessorCommonLib {
     error InvalidTimestamp(uint64 _timestamp);
 
     /**
-     * @dev calculate the start time based upon the starting hour sent in. Essentially, get the start timestamp for the last time the clock was at the hour indicated.
-     * @param _startingHour the starting hour from the rule
-     * @return startingTimestamp the period starting timestamp
-     */
-    function calculateStartDate(uint8 _startingHour) internal view returns (uint64) {
-        return uint64(block.timestamp - (block.timestamp % (1 days)) - 1 days + uint256(_startingHour) * (1 hours));
-    }
-
-    /**
      * @dev Determine is the rule is active. This is only for use in rules that are stored with activation timestamps.
      */
     function isRuleActive(uint64 _startTs) internal view returns (bool) {

--- a/src/economic/ruleStorage/RuleDataFacet.sol
+++ b/src/economic/ruleStorage/RuleDataFacet.sol
@@ -7,7 +7,7 @@ import {RuleStoragePositionLib as Storage} from "./RuleStoragePositionLib.sol";
 import {INonTaggedRules as NonTaggedRules} from "./RuleDataInterfaces.sol";
 import {IRuleStorage as RuleS} from "./IRuleStorage.sol";
 import {IEconomicEvents} from "../../interfaces/IEvents.sol";
-import {IInputErrors, ITagInputErrors, IZeroAddressError, IAppRuleInputErrors, IRuleStorageErrors} from "../../interfaces/IErrors.sol";
+import {IInputErrors, ITagInputErrors, IZeroAddressError, IAppRuleInputErrors} from "../../interfaces/IErrors.sol";
 import "./RuleCodeData.sol";
 import "./RuleStorageCommonLib.sol";
 
@@ -19,6 +19,7 @@ import "./RuleStorageCommonLib.sol";
  */
 contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInputErrors, ITagInputErrors, IZeroAddressError, IAppRuleInputErrors {
     using RuleStorageCommonLib for uint64;
+    using RuleStorageCommonLib for uint32;
 
     /**
      * Note that no update method is implemented for rules. Since reutilization of
@@ -64,9 +65,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return percentagePurchaseRules rule at index position
      */
     function getPctPurchaseRule(uint32 _index) external view returns (NonTaggedRules.TokenPercentagePurchaseRule memory) {
-        RuleS.PctPurchaseRuleS storage data = Storage.pctPurchaseStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.percentagePurchaseRules[_index].startTime == 0) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalPctPurchaseRule());
+        RuleS.PctPurchaseRuleS storage data = Storage.pctPurchaseStorage();
         return data.percentagePurchaseRules[_index];
     }
 
@@ -74,7 +75,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Token Purchase Percentage
      * @return Total length of array
      */
-    function getTotalPctPurchaseRule() external view returns (uint32) {
+    function getTotalPctPurchaseRule() public view returns (uint32) {
         RuleS.PctPurchaseRuleS storage data = Storage.pctPurchaseStorage();
         return data.percentagePurchaseRuleIndex;
     }
@@ -117,9 +118,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return percentageSellRules rule at index position
      */
     function getPctSellRule(uint32 _index) external view returns (NonTaggedRules.TokenPercentageSellRule memory) {
-        RuleS.PctSellRuleS storage data = Storage.pctSellStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.percentageSellRules[_index].startTime == 0) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalPctSellRule());
+        RuleS.PctSellRuleS storage data = Storage.pctSellStorage();
         return data.percentageSellRules[_index];
     }
 
@@ -127,7 +128,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Token Percentage Sell
      * @return Total length of array
      */
-    function getTotalPctSellRule() external view returns (uint32) {
+    function getTotalPctSellRule() public view returns (uint32) {
         RuleS.PctSellRuleS storage data = Storage.pctSellStorage();
         return data.percentageSellRuleIndex;
     }
@@ -160,9 +161,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return TokenPurchaseFeeByVolume rule at index position
      */
     function getPurchaseFeeByVolumeRule(uint32 _index) external view returns (NonTaggedRules.TokenPurchaseFeeByVolume memory) {
-        RuleS.PurchaseFeeByVolRuleS storage data = Storage.purchaseFeeByVolumeStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.purchaseFeeByVolumeRules[_index].volume == 0) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalTokenPurchaseFeeByVolumeRules());
+        RuleS.PurchaseFeeByVolRuleS storage data = Storage.purchaseFeeByVolumeStorage();
         return data.purchaseFeeByVolumeRules[_index];
     }
 
@@ -170,7 +171,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Token Purchase Percentage
      * @return Total length of array
      */
-    function getTotalTokenPurchaseFeeByVolumeRules() external view returns (uint32) {
+    function getTotalTokenPurchaseFeeByVolumeRules() public view returns (uint32) {
         RuleS.PurchaseFeeByVolRuleS storage data = Storage.purchaseFeeByVolumeStorage();
         return data.purchaseFeeByVolumeRuleIndex;
     }
@@ -211,9 +212,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return volatilityRules rule at index position
      */
     function getVolatilityRule(uint32 _index) external view returns (NonTaggedRules.TokenVolatilityRule memory) {
-        RuleS.VolatilityRuleS storage data = Storage.priceVolatilityStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.volatilityRules[_index].maxVolatility == 0) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalVolatilityRules());
+        RuleS.VolatilityRuleS storage data = Storage.priceVolatilityStorage();
         return data.volatilityRules[_index];
     }
 
@@ -221,7 +222,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Volatility rules
      * @return Total length of array
      */
-    function getTotalVolatilityRules() external view returns (uint32) {
+    function getTotalVolatilityRules() public view returns (uint32) {
         RuleS.VolatilityRuleS storage data = Storage.priceVolatilityStorage();
         return data.volatilityRuleIndex;
     }
@@ -263,9 +264,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return TokenTransferVolumeRule rule at index position
      */
     function getTransferVolumeRule(uint32 _index) external view returns (NonTaggedRules.TokenTransferVolumeRule memory) {
-        RuleS.TransferVolRuleS storage data = Storage.volumeStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.transferVolumeRules[_index].maxVolume == 0) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalTransferVolumeRules());
+        RuleS.TransferVolRuleS storage data = Storage.volumeStorage();
         return data.transferVolumeRules[_index];
     }
 
@@ -273,7 +274,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Token Transfer Volume rules
      * @return Total length of array
      */
-    function getTotalTransferVolumeRules() external view returns (uint32) {
+    function getTotalTransferVolumeRules() public view returns (uint32) {
         RuleS.TransferVolRuleS storage data = Storage.volumeStorage();
         return uint32(data.transferVolumeRules.length);
     }
@@ -303,6 +304,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return Rule at index
      */
     function getMinimumTransferRule(uint32 _index) external view returns (uint256) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalMinimumTransferRules());
         RuleS.MinTransferRuleS storage data = Storage.minTransferStorage();
         return data.minimumTransferRules[_index];
     }
@@ -311,7 +314,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Minimum Transfer rules
      * @return Total length of array
      */
-    function getTotalMinimumTransferRules() external view returns (uint32) {
+    function getTotalMinimumTransferRules() public view returns (uint32) {
         RuleS.MinTransferRuleS storage data = Storage.minTransferStorage();
         return uint32(data.minimumTransferRules.length);
     }
@@ -352,9 +355,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return SupplyVolatilityRule rule at indexed postion
      */
     function getSupplyVolatilityRule(uint32 _index) external view returns (NonTaggedRules.SupplyVolatilityRule memory) {
-        RuleS.SupplyVolatilityRuleS storage data = Storage.supplyVolatilityStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.supplyVolatilityRules[_index].period == 0) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalSupplyVolatilityRules());
+        RuleS.SupplyVolatilityRuleS storage data = Storage.supplyVolatilityStorage();
         return data.supplyVolatilityRules[_index];
     }
 
@@ -362,7 +365,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function to get total Supply Volitility rules
      * @return supplyVolatilityRules total length of array
      */
-    function getTotalSupplyVolatilityRules() external view returns (uint32) {
+    function getTotalSupplyVolatilityRules() public view returns (uint32) {
         RuleS.SupplyVolatilityRuleS storage data = Storage.supplyVolatilityStorage();
         return data.supplyVolatilityRuleIndex;
     }
@@ -395,9 +398,9 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @return OracleRule at index
      */
     function getOracleRule(uint32 _index) external view returns (NonTaggedRules.OracleRule memory) {
-        RuleS.OracleRuleS storage data = Storage.oracleStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (data.oracleRules[_index].oracleAddress == address(0)) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalOracleRules());
+        RuleS.OracleRuleS storage data = Storage.oracleStorage();
         return data.oracleRules[_index];
     }
 
@@ -405,7 +408,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function get total Oracle rules
      * @return total oracleRules array length
      */
-    function getTotalOracleRules() external view returns (uint32) {
+    function getTotalOracleRules() public view returns (uint32) {
         RuleS.OracleRuleS storage data = Storage.oracleStorage();
         return data.oracleRuleIndex;
     }
@@ -466,7 +469,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
     function getNFTTransferCounterRule(uint32 _index, bytes32 _nftType) external view returns (NonTaggedRules.NFTTradeCounterRule memory) {
         RuleS.NFTTransferCounterRuleS storage data = Storage.nftTransferStorage();
         // check one of the required non zero values to check for existence, if not, revert
-        if (!data.NFTTransferCounterRule[_index][_nftType].active) revert RuleDoesNotExist();
+        _index.checkRuleExistence(getTotalNFTTransferCounterRules());
         return data.NFTTransferCounterRule[_index][_nftType];
     }
 
@@ -474,7 +477,7 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      * @dev Function gets total NFT Trade Counter rules
      * @return Total length of array
      */
-    function getTotalNFTTransferCounterRules() external view returns (uint32) {
+    function getTotalNFTTransferCounterRules() public view returns (uint32) {
         RuleS.NFTTransferCounterRuleS storage data = Storage.nftTransferStorage();
         return data.NFTTransferCounterRuleIndex;
     }

--- a/src/economic/ruleStorage/RuleDataFacet.sol
+++ b/src/economic/ruleStorage/RuleDataFacet.sol
@@ -7,7 +7,7 @@ import {RuleStoragePositionLib as Storage} from "./RuleStoragePositionLib.sol";
 import {INonTaggedRules as NonTaggedRules} from "./RuleDataInterfaces.sol";
 import {IRuleStorage as RuleS} from "./IRuleStorage.sol";
 import {IEconomicEvents} from "../../interfaces/IEvents.sol";
-import {IInputErrors, ITagInputErrors, IZeroAddressError, IAppRuleInputErrors} from "../../interfaces/IErrors.sol";
+import {IInputErrors, ITagInputErrors, IZeroAddressError, IAppRuleInputErrors, IRuleStorageErrors} from "../../interfaces/IErrors.sol";
 import "./RuleCodeData.sol";
 import "./RuleStorageCommonLib.sol";
 
@@ -65,6 +65,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getPctPurchaseRule(uint32 _index) external view returns (NonTaggedRules.TokenPercentagePurchaseRule memory) {
         RuleS.PctPurchaseRuleS storage data = Storage.pctPurchaseStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.percentagePurchaseRules[_index].startTime == 0) revert RuleDoesNotExist();
         return data.percentagePurchaseRules[_index];
     }
 
@@ -116,6 +118,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getPctSellRule(uint32 _index) external view returns (NonTaggedRules.TokenPercentageSellRule memory) {
         RuleS.PctSellRuleS storage data = Storage.pctSellStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.percentageSellRules[_index].startTime == 0) revert RuleDoesNotExist();
         return data.percentageSellRules[_index];
     }
 
@@ -157,6 +161,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getPurchaseFeeByVolumeRule(uint32 _index) external view returns (NonTaggedRules.TokenPurchaseFeeByVolume memory) {
         RuleS.PurchaseFeeByVolRuleS storage data = Storage.purchaseFeeByVolumeStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.purchaseFeeByVolumeRules[_index].volume == 0) revert RuleDoesNotExist();
         return data.purchaseFeeByVolumeRules[_index];
     }
 
@@ -206,6 +212,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getVolatilityRule(uint32 _index) external view returns (NonTaggedRules.TokenVolatilityRule memory) {
         RuleS.VolatilityRuleS storage data = Storage.priceVolatilityStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.volatilityRules[_index].maxVolatility == 0) revert RuleDoesNotExist();
         return data.volatilityRules[_index];
     }
 
@@ -256,6 +264,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getTransferVolumeRule(uint32 _index) external view returns (NonTaggedRules.TokenTransferVolumeRule memory) {
         RuleS.TransferVolRuleS storage data = Storage.volumeStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.transferVolumeRules[_index].maxVolume == 0) revert RuleDoesNotExist();
         return data.transferVolumeRules[_index];
     }
 
@@ -343,6 +353,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getSupplyVolatilityRule(uint32 _index) external view returns (NonTaggedRules.SupplyVolatilityRule memory) {
         RuleS.SupplyVolatilityRuleS storage data = Storage.supplyVolatilityStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.supplyVolatilityRules[_index].period == 0) revert RuleDoesNotExist();
         return data.supplyVolatilityRules[_index];
     }
 
@@ -384,6 +396,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getOracleRule(uint32 _index) external view returns (NonTaggedRules.OracleRule memory) {
         RuleS.OracleRuleS storage data = Storage.oracleStorage();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (data.oracleRules[_index].oracleAddress == address(0)) revert RuleDoesNotExist();
         return data.oracleRules[_index];
     }
 
@@ -451,7 +465,8 @@ contract RuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInput
      */
     function getNFTTransferCounterRule(uint32 _index, bytes32 _nftType) external view returns (NonTaggedRules.NFTTradeCounterRule memory) {
         RuleS.NFTTransferCounterRuleS storage data = Storage.nftTransferStorage();
-        if (_index >= data.NFTTransferCounterRuleIndex) revert IndexOutOfRange();
+        // check one of the required non zero values to check for existence, if not, revert
+        if (!data.NFTTransferCounterRule[_index][_nftType].active) revert RuleDoesNotExist();
         return data.NFTTransferCounterRule[_index][_nftType];
     }
 

--- a/src/economic/ruleStorage/RuleStorageCommonLib.sol
+++ b/src/economic/ruleStorage/RuleStorageCommonLib.sol
@@ -26,7 +26,7 @@ library RuleStorageCommonLib {
      * @return _exists true if it exists, false if not
      */
     function checkRuleExistence(uint32 _ruleIndex, uint32 _ruleTotal) internal pure returns (bool) {
-        if ((_ruleTotal > 0 && _ruleTotal <= _ruleIndex) || _ruleTotal == 0) {
+        if (_ruleTotal <= _ruleIndex) {
             revert RuleDoesNotExist();
         } else {
             return true;

--- a/src/economic/ruleStorage/RuleStorageCommonLib.sol
+++ b/src/economic/ruleStorage/RuleStorageCommonLib.sol
@@ -8,6 +8,7 @@ pragma solidity 0.8.17;
  */
 library RuleStorageCommonLib {
     error InvalidTimestamp(uint64 _timestamp);
+    error RuleDoesNotExist();
 
     /**
      * @dev validate a user entered timestamp to ensure that it is valid. Validity depends on it being greater than UNIX epoch and not more than 1 year into the future. It reverts with custom error if invalid
@@ -15,6 +16,20 @@ library RuleStorageCommonLib {
     function validateTimestamp(uint64 _startTimestamp) internal view {
         if (_startTimestamp == 0 || _startTimestamp > (block.timestamp + (52 * 1 weeks))) {
             revert InvalidTimestamp(_startTimestamp);
+        }
+    }
+
+    /**
+     * @dev generic function to check the existence of a rule
+     * @param _ruleIndex index of the current rule
+     * @param _ruleTotal total rules in existence for the rule type
+     * @return _exists true if it exists, false if not
+     */
+    function checkRuleExistence(uint32 _ruleIndex, uint32 _ruleTotal) internal pure returns (bool) {
+        if ((_ruleTotal > 0 && _ruleTotal <= _ruleIndex) || _ruleTotal == 0) {
+            revert RuleDoesNotExist();
+        } else {
+            return true;
         }
     }
 }

--- a/src/economic/ruleStorage/TaggedRuleDataFacet.sol
+++ b/src/economic/ruleStorage/TaggedRuleDataFacet.sol
@@ -18,6 +18,7 @@ import "./RuleStorageCommonLib.sol";
  */
 contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, IInputErrors, IRiskInputErrors, ITagInputErrors, ITagRuleInputErrors, IZeroAddressError {
     using RuleStorageCommonLib for uint64;
+    using RuleStorageCommonLib for uint32;
 
     /**
      * Note that no update method is implemented. Since reutilization of
@@ -81,6 +82,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return PurchaseRule rule at index position
      */
     function getPurchaseRule(uint32 _index, bytes32 _accountType) external view returns (TaggedRules.PurchaseRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalPurchaseRule());
         RuleS.PurchaseRuleS storage data = Storage.purchaseStorage();
         if (_index >= data.purchaseRulesIndex) revert IndexOutOfRange();
         return data.purchaseRulesPerUser[_index][_accountType];
@@ -90,7 +93,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function to get total purchase rules
      * @return Total length of array
      */
-    function getTotalPurchaseRule() external view returns (uint32) {
+    function getTotalPurchaseRule() public view returns (uint32) {
         RuleS.PurchaseRuleS storage data = Storage.purchaseStorage();
         return data.purchaseRulesIndex;
     }
@@ -151,6 +154,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return SellRule at position in array
      */
     function getSellRuleByIndex(uint32 _index, bytes32 _accountType) external view returns (TaggedRules.SellRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalSellRule());
         RuleS.SellRuleS storage data = Storage.sellStorage();
         if (_index >= data.sellRulesIndex) revert IndexOutOfRange();
         return data.sellRulesPerUser[_index][_accountType];
@@ -160,7 +165,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function to get total Sell rules
      * @return Total length of array
      */
-    function getTotalSellRule() external view returns (uint32) {
+    function getTotalSellRule() public view returns (uint32) {
         RuleS.SellRuleS storage data = Storage.sellStorage();
         return data.sellRulesIndex;
     }
@@ -219,6 +224,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return BalanceLimitRule at index location in array
      */
     function getBalanceLimitRule(uint32 _index, bytes32 _accountType) external view returns (TaggedRules.BalanceLimitRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalBalanceLimitRules());
         RuleS.BalanceLimitRuleS storage data = Storage.balanceLimitStorage();
         if (_index >= data.balanceLimitRuleIndex) revert IndexOutOfRange();
         return data.balanceLimitsPerAccountType[_index][_accountType];
@@ -228,7 +235,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function gets total Balance Limit rules
      * @return Total length of array
      */
-    function getTotalBalanceLimitRules() external view returns (uint32) {
+    function getTotalBalanceLimitRules() public view returns (uint32) {
         RuleS.BalanceLimitRuleS storage data = Storage.balanceLimitStorage();
         return data.balanceLimitRuleIndex;
     }
@@ -286,6 +293,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return WithdrawalRule rule at indexed postion
      */
     function getWithdrawalRule(uint32 _index, bytes32 _accountType) external view returns (TaggedRules.WithdrawalRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalWithdrawalRule());
         RuleS.WithdrawalRuleS storage data = Storage.withdrawalStorage();
         if (_index >= data.withdrawalRulesIndex) revert IndexOutOfRange();
         return data.withdrawalRulesPerToken[_index][_accountType];
@@ -295,7 +304,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function to get total withdrawal rules
      * @return withdrawalRulesIndex total length of array
      */
-    function getTotalWithdrawalRule() external view returns (uint32) {
+    function getTotalWithdrawalRule() public view returns (uint32) {
         RuleS.WithdrawalRuleS storage data = Storage.withdrawalStorage();
         return data.withdrawalRulesIndex;
     }
@@ -328,6 +337,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return adminWithdrawalRulesPerToken rule at indexed postion
      */
     function getAdminWithdrawalRule(uint32 _index) external view returns (TaggedRules.AdminWithdrawalRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalAdminWithdrawalRules());
         RuleS.AdminWithdrawalRuleS storage data = Storage.adminWithdrawalStorage();
         if (_index >= data.adminWithdrawalRulesIndex) revert IndexOutOfRange();
         return data.adminWithdrawalRulesPerToken[_index];
@@ -337,7 +348,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function to get total Admin withdrawal rules
      * @return adminWithdrawalRulesPerToken total length of array
      */
-    function getTotalAdminWithdrawalRules() external view returns (uint32) {
+    function getTotalAdminWithdrawalRules() public view returns (uint32) {
         RuleS.AdminWithdrawalRuleS storage data = Storage.adminWithdrawalStorage();
         return data.adminWithdrawalRulesIndex;
     }
@@ -400,6 +411,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return balanceAmount balance allowed for access levellevel
      */
     function getTransactionLimitByRiskRule(uint32 _index) external view returns (TaggedRules.TransactionSizeToRiskRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalTransactionLimitByRiskRules());
         RuleS.TxSizeToRiskRuleS storage data = Storage.txSizeToRiskStorage();
         if (_index >= data.txSizeToRiskRuleIndex) revert IndexOutOfRange();
         return data.txSizeToRiskRule[_index];
@@ -409,7 +422,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function to get total Transaction Limit by Risk Score rules
      * @return Total length of array
      */
-    function getTotalTransactionLimitByRiskRules() external view returns (uint32) {
+    function getTotalTransactionLimitByRiskRules() public view returns (uint32) {
         RuleS.TxSizeToRiskRuleS storage data = Storage.txSizeToRiskStorage();
         return data.txSizeToRiskRuleIndex;
     }
@@ -475,6 +488,8 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @return PurchaseRule rule at index position
      */
     function getMinBalByDateRule(uint32 _index, bytes32 _accountTag) external view returns (TaggedRules.MinBalByDateRule memory) {
+        // check one of the required non zero values to check for existence, if not, revert
+        _index.checkRuleExistence(getTotalMinBalByDateRule());
         RuleS.MinBalByDateRuleS storage data = Storage.minBalByDateRuleStorage();
         if (_index >= data.minBalByDateRulesIndex) revert IndexOutOfRange();
         return data.minBalByDateRulesPerUser[_index][_accountTag];
@@ -484,7 +499,7 @@ contract TaggedRuleDataFacet is Context, AppAdministratorOnly, IEconomicEvents, 
      * @dev Function to get total minimum balance by date rules
      * @return Total length of array
      */
-    function getTotalMinBalByDateRule() external view returns (uint32) {
+    function getTotalMinBalByDateRule() public view returns (uint32) {
         RuleS.MinBalByDateRuleS storage data = Storage.minBalByDateRuleStorage();
         return data.minBalByDateRulesIndex;
     }

--- a/src/interfaces/IErrors.sol
+++ b/src/interfaces/IErrors.sol
@@ -17,10 +17,6 @@ interface IRuleProcessorErrors {
     error RuleDoesNotExist();
 }
 
-interface IRuleStorageErrors {
-    error RuleDoesNotExist();
-}
-
 interface IAccessLevelErrors {
     error BalanceExceedsAccessLevelAllowedLimit();
     error WithdrawalExceedsAccessLevelAllowedLimit();

--- a/src/interfaces/IErrors.sol
+++ b/src/interfaces/IErrors.sol
@@ -17,6 +17,10 @@ interface IRuleProcessorErrors {
     error RuleDoesNotExist();
 }
 
+interface IRuleStorageErrors {
+    error RuleDoesNotExist();
+}
+
 interface IAccessLevelErrors {
     error BalanceExceedsAccessLevelAllowedLimit();
     error WithdrawalExceedsAccessLevelAllowedLimit();

--- a/src/token/ProtocolERC20Handler.sol
+++ b/src/token/ProtocolERC20Handler.sol
@@ -334,6 +334,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setMinMaxBalanceRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateMinMaxAccountBalance(_ruleId);
         minMaxBalanceRuleId = _ruleId;
         minMaxBalanceRuleActive = true;
         emit ApplicationHandlerApplied(MIN_MAX_BALANCE_LIMIT, address(this), _ruleId);
@@ -374,6 +375,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setMinTransferRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateMinTransfer(_ruleId);
         minTransferRuleId = _ruleId;
         minTransferRuleActive = true;
         emit ApplicationHandlerApplied(MIN_TRANSFER, address(this), _ruleId);
@@ -414,6 +416,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setOracleRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateOracle(_ruleId);
         oracleRuleId = _ruleId;
         oracleRuleActive = true;
         emit ApplicationHandlerApplied(ORACLE, address(this), _ruleId);
@@ -462,6 +465,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setTransactionLimitByRiskRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateTransactionLimitByRiskScore(_ruleId);
         transactionLimitByRiskRuleId = _ruleId;
         transactionLimitByRiskRuleActive = true;
         emit ApplicationHandlerApplied(TX_SIZE_BY_RISK, address(this), _ruleId);
@@ -494,6 +498,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setAdminWithdrawalRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateAdminWithdrawal(_ruleId);
         /// if the rule is currently active, we check that time for current ruleId is expired. Revert if not expired.
         if (adminWithdrawalActive) {
             ruleProcessor.checkAdminWithdrawalRule(adminWithdrawalRuleId, 1, 1);
@@ -551,6 +556,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setMinBalByDateRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateMinBalByDate(_ruleId);
         minBalByDateRuleId = _ruleId;
         minBalByDateRuleActive = true;
         emit ApplicationHandlerApplied(MIN_ACCT_BAL_BY_DATE, address(this), _ruleId);
@@ -591,6 +597,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setTokenTransferVolumeRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateTokenTransferVolume(_ruleId);
         tokenTransferVolumeRuleId = _ruleId;
         tokenTransferVolumeRuleActive = true;
         emit ApplicationHandlerApplied(TRANSFER_VOLUME, address(this), _ruleId);
@@ -631,6 +638,7 @@ contract ProtocolERC20Handler is Ownable, ProtocolHandlerCommon, AppAdministrato
      * @param _ruleId Rule Id to set
      */
     function setTotalSupplyVolatilityRuleId(uint32 _ruleId) external appAdministratorOnly(appManagerAddress) {
+        ruleProcessor.validateSupplyVolatility(_ruleId);
         totalSupplyVolatilityRuleId = _ruleId;
         totalSupplyVolatilityRuleActive = true;
         emit ApplicationHandlerApplied(SUPPLY_VOLATILITY, address(this), _ruleId);

--- a/src/token/ProtocolERC721Handler.sol
+++ b/src/token/ProtocolERC721Handler.sol
@@ -236,6 +236,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setMinMaxBalanceRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateMinMaxAccountBalance(_ruleId);
         minMaxBalanceRuleId = _ruleId;
         minMaxBalanceRuleActive = true;
         emit ApplicationHandlerApplied(MIN_MAX_BALANCE_LIMIT, address(this), _ruleId);
@@ -276,6 +277,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setOracleRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateOracle(_ruleId);
         oracleRuleId = _ruleId;
         oracleRuleActive = true;
         emit ApplicationHandlerApplied(ORACLE, address(this), _ruleId);
@@ -316,6 +318,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setTradeCounterRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateNFTTransferCounter(_ruleId);
         tradeCounterRuleId = _ruleId;
         tradeCounterRuleActive = true;
         emit ApplicationHandlerApplied(NFT_TRANSFER, address(this), _ruleId);
@@ -373,6 +376,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setTransactionLimitByRiskRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateTransactionLimitByRiskScore(_ruleId);
         transactionLimitByRiskRuleId = _ruleId;
         transactionLimitByRiskRuleActive = true;
         emit ApplicationHandlerApplied(TX_SIZE_BY_RISK, address(this), _ruleId);
@@ -413,6 +417,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setMinBalByDateRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateMinBalByDate(_ruleId);
         minBalByDateRuleId = _ruleId;
         minBalByDateRuleActive = true;
         emit ApplicationHandlerApplied(MIN_ACCT_BAL_BY_DATE, address(this), _ruleId);
@@ -445,6 +450,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setAdminWithdrawalRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateAdminWithdrawal(_ruleId);
         /// if the rule is currently active, we check that time for current ruleId is expired. Revert if not expired.
         if (adminWithdrawalActive) {
             ruleProcessor.checkAdminWithdrawalRule(adminWithdrawalRuleId, 1, 1);
@@ -502,6 +508,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setTokenTransferVolumeRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateTokenTransferVolume(_ruleId);
         tokenTransferVolumeRuleId = _ruleId;
         tokenTransferVolumeRuleActive = true;
         emit ApplicationHandlerApplied(TRANSFER_VOLUME, address(this), _ruleId);
@@ -534,6 +541,7 @@ contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon {
      * @param _ruleId Rule Id to set
      */
     function setTotalSupplyVolatilityRuleId(uint32 _ruleId) external appAdministratorOrOwnerOnly(appManagerAddress) {
+        ruleProcessor.validateSupplyVolatility(_ruleId);
         totalSupplyVolatilityRuleId = _ruleId;
         totalSupplyVolatilityRuleActive = true;
         emit ApplicationHandlerApplied(SUPPLY_VOLATILITY, address(this), _ruleId);

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -20,7 +20,7 @@ import "src/application/IAppManagerUser.sol";
  * @notice This contract contains common variables and functions for all Protocol Asset Handlers
  */
 
-abstract contract ProtocolHandlerCommon is IAppManagerUser, IOwnershipErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
+contract ProtocolHandlerCommon is IAppManagerUser, IOwnershipErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
     address private newAppManagerAddress;
     address public appManagerAddress;
     IRuleProcessor ruleProcessor;

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -20,7 +20,7 @@ import "src/application/IAppManagerUser.sol";
  * @notice This contract contains common variables and functions for all Protocol Asset Handlers
  */
 
-contract ProtocolHandlerCommon is IAppManagerUser, IOwnershipErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
+abstract contract ProtocolHandlerCommon is IAppManagerUser, IOwnershipErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
     address private newAppManagerAddress;
     address public appManagerAddress;
     IRuleProcessor ruleProcessor;

--- a/test/ApplicationERC20Fuzz.t.sol
+++ b/test/ApplicationERC20Fuzz.t.sol
@@ -601,12 +601,12 @@ contract ApplicationERC20FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestUt
         uint32 _index = TaggedRuleDataFacet(address(ruleStorageDiamond)).addAdminWithdrawalRule(address(appManager), 1_000_000 * (10 ** 18), block.timestamp + 365 days);
 
         applicationCoinHandler.setAdminWithdrawalRuleId(_index);
-
+        _index = TaggedRuleDataFacet(address(ruleStorageDiamond)).addAdminWithdrawalRule(address(appManager), 1_000_000 * (10 ** 18), block.timestamp + 365 days);
         /// check that we cannot change the rule or turn it off while the current rule is still active
         vm.expectRevert();
         applicationCoinHandler.activateAdminWithdrawalRule(false);
         vm.expectRevert();
-        applicationCoinHandler.setAdminWithdrawalRuleId(1);
+        applicationCoinHandler.setAdminWithdrawalRuleId(_index);
 
         vm.warp(block.timestamp + secondsForward);
         if (secondsForward < 365 days && type(uint256).max - amount < 1_000_000 * (10 ** 18)) vm.expectRevert();
@@ -615,7 +615,7 @@ contract ApplicationERC20FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestUt
         /// if last rule is expired, we should be able to turn off and update the rule
         if (secondsForward >= 365 days) {
             applicationCoinHandler.activateAdminWithdrawalRule(false);
-            applicationCoinHandler.setAdminWithdrawalRuleId(1);
+            applicationCoinHandler.setAdminWithdrawalRuleId(_index);
         }
     }
 

--- a/test/ApplicationERC721.t.sol
+++ b/test/ApplicationERC721.t.sol
@@ -645,12 +645,13 @@ contract ApplicationERC721Test is DiamondTestUtil, RuleProcessorDiamondTestUtil 
 
         /// Set the rule in the handler
         applicationNFTHandler.setAdminWithdrawalRuleId(_index);
+        _index = TaggedRuleDataFacet(address(ruleStorageDiamond)).addAdminWithdrawalRule(address(appManager), 5, block.timestamp + 365 days);
 
         /// check that we cannot change the rule or turn it off while the current rule is still active
         vm.expectRevert();
         applicationNFTHandler.activateAdminWithdrawalRule(false);
         vm.expectRevert();
-        applicationNFTHandler.setAdminWithdrawalRuleId(1);
+        applicationNFTHandler.setAdminWithdrawalRuleId(_index);
 
         /// These transfers should pass
         applicationNFT.safeTransferFrom(defaultAdmin, user1, 0);
@@ -665,7 +666,7 @@ contract ApplicationERC721Test is DiamondTestUtil, RuleProcessorDiamondTestUtil 
         /// Transfers and updating rules should now pass
         applicationNFT.safeTransferFrom(defaultAdmin, user1, 2);
         applicationNFTHandler.activateAdminWithdrawalRule(false);
-        applicationNFTHandler.setAdminWithdrawalRuleId(1);
+        applicationNFTHandler.setAdminWithdrawalRuleId(_index);
     }
 
     /// test the transfer volume rule in erc721

--- a/test/ApplicationERC721Fuzz.t.sol
+++ b/test/ApplicationERC721Fuzz.t.sol
@@ -1477,12 +1477,12 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         uint32 _index = TaggedRuleDataFacet(address(ruleStorageDiamond)).addAdminWithdrawalRule(address(appManager), 5, block.timestamp + 365 days);
         /// Set the rule in the handler
         applicationNFTHandler.setAdminWithdrawalRuleId(_index);
-
+        _index = TaggedRuleDataFacet(address(ruleStorageDiamond)).addAdminWithdrawalRule(address(appManager), 5, block.timestamp + 365 days);
         /// check that we cannot change the rule or turn it off while the current rule is still active
         vm.expectRevert();
         applicationNFTHandler.activateAdminWithdrawalRule(false);
         vm.expectRevert();
-        applicationNFTHandler.setAdminWithdrawalRuleId(1);
+        applicationNFTHandler.setAdminWithdrawalRuleId(_index);
 
         /// These transfers should pass
         applicationNFT.safeTransferFrom(defaultAdmin, user1, 0);
@@ -1497,7 +1497,7 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
 
         if (daysForward >= 365 days) {
             applicationNFTHandler.activateAdminWithdrawalRule(false);
-            applicationNFTHandler.setAdminWithdrawalRuleId(1);
+            applicationNFTHandler.setAdminWithdrawalRuleId(_index);
         }
     }
 

--- a/test/ApplicationERC721U.t.sol
+++ b/test/ApplicationERC721U.t.sol
@@ -704,12 +704,13 @@ contract ApplicationERC721UTest is DiamondTestUtil, RuleProcessorDiamondTestUtil
 
         /// Set the rule in the handler
         applicationNFTHandler.setAdminWithdrawalRuleId(_index);
+        _index = TaggedRuleDataFacet(address(ruleStorageDiamond)).addAdminWithdrawalRule(address(appManager), 5, block.timestamp + 365 days);
 
         /// check that we cannot change the rule or turn it off while the current rule is still active
         vm.expectRevert();
         applicationNFTHandler.activateAdminWithdrawalRule(false);
         vm.expectRevert();
-        applicationNFTHandler.setAdminWithdrawalRuleId(1);
+        applicationNFTHandler.setAdminWithdrawalRuleId(_index);
 
         /// These transfers should pass
         ApplicationERC721U(address(applicationNFTProxy)).safeTransferFrom(defaultAdmin, user1, 0);
@@ -734,7 +735,7 @@ contract ApplicationERC721UTest is DiamondTestUtil, RuleProcessorDiamondTestUtil
         /// Transfers and updating rules should now pass
         ApplicationERC721U(address(applicationNFTProxy)).safeTransferFrom(defaultAdmin, user1, 2);
         applicationNFTHandler.activateAdminWithdrawalRule(false);
-        applicationNFTHandler.setAdminWithdrawalRuleId(1);
+        applicationNFTHandler.setAdminWithdrawalRuleId(_index);
     }
 
     function testUpgradeAppManager721u() public {

--- a/test/RuleProcessorDiamondTestUtil.sol
+++ b/test/RuleProcessorDiamondTestUtil.sol
@@ -24,7 +24,7 @@ contract RuleProcessorDiamondTestUtil is GenerateSelectors, RuleStorageDiamondTe
         DiamondInit diamondInit = new DiamondInit();
 
         // Register all facets.
-        string[11] memory facets = [
+        string[12] memory facets = [
             // Native facets,
             "ProtocolNativeFacet",
             // Raw implementation facets.
@@ -40,7 +40,8 @@ contract RuleProcessorDiamondTestUtil is GenerateSelectors, RuleStorageDiamondTe
             //TaggedRuleFacets:
             "ERC20TaggedRuleProcessorFacet",
             "ERC721TaggedRuleProcessorFacet",
-            "RiskTaggedRuleProcessorFacet"
+            "RiskTaggedRuleProcessorFacet",
+            "RuleApplicationValidationFacet"
         ];
 
         string[] memory inputs = new string[](3);


### PR DESCRIPTION
Added custom errors to all rule getters. NOTE: This does not include the tagged rules because they must check differently due to a user having a tag that is not covered by the rule.

This closes #78 