### PR TITLE
52 audit missing validation safemint 16

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,8 +14,8 @@ eth-rpc-url = 'http://172.20.0.2:10002'
 
 remappings = ["forge-std/=lib/forge-std/src/",
     "ds-test/=lib/forge-std/lib/ds-test/src/",
-    "openzeppelin-contracts/=lib/openzeppelin-contracts/",
-"openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
+    "@openzeppelin/=lib/openzeppelin-contracts/",
+"@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
 "diamond-std/=lib/diamond-std/",]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -2,5 +2,27 @@
   "devDependencies": {
     "prettier": "^2.8.3",
     "prettier-plugin-solidity": "^1.1.1"
-  }
+  },
+  "name": "@thrackle-io/tron",
+  "description": "[![Project Version][version-image]][version-url]",
+  "version": "1.0.0",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs",
+    "lib": "lib",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thrackle-io/Tron.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/thrackle-io/Tron/issues"
+  },
+  "homepage": "https://github.com/thrackle-io/Tron#readme"
 }

--- a/package.json
+++ b/package.json
@@ -2,27 +2,5 @@
   "devDependencies": {
     "prettier": "^2.8.3",
     "prettier-plugin-solidity": "^1.1.1"
-  },
-  "name": "@thrackle-io/tron",
-  "description": "[![Project Version][version-image]][version-url]",
-  "version": "1.0.0",
-  "main": "index.js",
-  "directories": {
-    "doc": "docs",
-    "lib": "lib",
-    "test": "test"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/thrackle-io/Tron.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/thrackle-io/Tron/issues"
-  },
-  "homepage": "https://github.com/thrackle-io/Tron#readme"
+  }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,5 @@
 forge-std/=lib/forge-std/src/
 ds-test/=lib/forge-std/lib/ds-test/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/
-openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/
+@openzeppelin/=lib/openzeppelin-contracts/
+@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/
 diamond-std/=lib/diamond-std/

--- a/src/application/AppManager.sol
+++ b/src/application/AppManager.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/access/AccessControlEnumerable.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165Checker.sol";
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "src/data/Accounts.sol";
 import "src/data/IAccounts.sol";
 import "src/data/IAccessLevels.sol";

--- a/src/application/AppManager.sol
+++ b/src/application/AppManager.sol
@@ -3,23 +3,23 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import "src/data/Accounts.sol";
-import "src/data/IAccounts.sol";
-import "src/data/IAccessLevels.sol";
-import "src/data/AccessLevels.sol";
-import "src/data/IRiskScores.sol";
-import "src/data/RiskScores.sol";
-import "src/data/IGeneralTags.sol";
-import "src/data/GeneralTags.sol";
-import "src/data/IPauseRules.sol";
-import "src/data/PauseRules.sol";
-import "src/application/ProtocolApplicationHandler.sol";
-import "src/economic/ruleProcessor/ActionEnum.sol";
-import {IAppLevelEvents} from "src/interfaces/IEvents.sol";
-import "src/application/IAppManagerUser.sol";
-import "src/data/IDataModule.sol";
-import "src/token/IAdminWithdrawalRuleCapable.sol";
-import "src/token/ProtocolTokenCommon.sol";
+import "../data/Accounts.sol";
+import "../data/IAccounts.sol";
+import "../data/IAccessLevels.sol";
+import "../data/AccessLevels.sol";
+import "../data/IRiskScores.sol";
+import "../data/RiskScores.sol";
+import "../data/IGeneralTags.sol";
+import "../data/GeneralTags.sol";
+import "../data/IPauseRules.sol";
+import "../data/PauseRules.sol";
+import "../application/ProtocolApplicationHandler.sol";
+import "../economic/ruleProcessor/ActionEnum.sol";
+import {IAppLevelEvents} from "../interfaces/IEvents.sol";
+import "../application/IAppManagerUser.sol";
+import "../data/IDataModule.sol";
+import "../token/IAdminWithdrawalRuleCapable.sol";
+import "../token/ProtocolTokenCommon.sol";
 
 /**
  * @title App Manager Contract

--- a/src/application/IAppManager.sol
+++ b/src/application/IAppManager.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "src/economic/ruleProcessor/ActionEnum.sol";
-import "src/data/IDataModule.sol";
-import "src/data/IPauseRules.sol";
-import {IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddressError, IOwnershipErrors} from "src/interfaces/IErrors.sol";
+import "../economic/ruleProcessor/ActionEnum.sol";
+import "../data/IDataModule.sol";
+import "../data/IPauseRules.sol";
+import {IAppManagerErrors, IAppAdministratorOnlyErrors, IInputErrors, IZeroAddressError, IOwnershipErrors} from "../interfaces/IErrors.sol";
 
 /**
  * @title App Manager Inquiry Interface

--- a/src/application/ProtocolApplicationHandler.sol
+++ b/src/application/ProtocolApplicationHandler.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.17;
 
 import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "src/economic/ruleProcessor/RuleProcessorDiamondLib.sol";
 import "../application/AppManager.sol";
 import "../economic/AppAdministratorOnly.sol";
 import "../economic/ruleStorage/RuleCodeData.sol";

--- a/src/application/ProtocolApplicationHandler.sol
+++ b/src/application/ProtocolApplicationHandler.sol
@@ -7,7 +7,7 @@ import "../economic/AppAdministratorOnly.sol";
 import "../economic/ruleStorage/RuleCodeData.sol";
 import {IApplicationHandlerEvents} from "../interfaces/IEvents.sol";
 import "../economic/IRuleProcessor.sol";
-import "src/economic/ruleProcessor/ActionEnum.sol";
+import "../economic/ruleProcessor/ActionEnum.sol";
 import {IZeroAddressError, IInputErrors} from "../interfaces/IErrors.sol";
 
 /**

--- a/src/application/ProtocolApplicationHandler.sol
+++ b/src/application/ProtocolApplicationHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "../application/AppManager.sol";
 import "../economic/AppAdministratorOnly.sol";
 import "../economic/ruleStorage/RuleCodeData.sol";

--- a/src/data/DataModule.sol
+++ b/src/data/DataModule.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "./IDataModule.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import {IAppManager} from "src/application/IAppManager.sol";
+import {IAppManager} from "../application/IAppManager.sol";
 import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 import {IAppManager} from "../application/IAppManager.sol";
 

--- a/src/data/DataModule.sol
+++ b/src/data/DataModule.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "./IDataModule.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import {IAppManager} from "src/application/IAppManager.sol";
 import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 import {IAppManager} from "../application/IAppManager.sol";

--- a/src/economic/AppAdministratorOnly.sol
+++ b/src/economic/AppAdministratorOnly.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import {IAppManager} from "../application/IAppManager.sol";
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import { IAppAdministratorOnlyErrors } from "../interfaces/IErrors.sol";
 
 /**

--- a/src/economic/AppAdministratorOnlyU.sol
+++ b/src/economic/AppAdministratorOnlyU.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import {IAppManager} from "../application/IAppManager.sol";
 import { IAppAdministratorOnlyErrors } from "../interfaces/IErrors.sol";
-import "openzeppelin-contracts-upgradeable/contracts/utils/ContextUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/utils/ContextUpgradeable.sol";
 
 /**
  * @title Application Administrators Only Modifier Contract

--- a/src/economic/AppAdministratorOrOwnerOnly.sol
+++ b/src/economic/AppAdministratorOrOwnerOnly.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 // import "./IAppAdministratorOrOwnerOnly.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import {IAppManager} from "../application/IAppManager.sol";
 import { IAppAdministratorOnlyErrors } from "../interfaces/IErrors.sol";
 

--- a/src/economic/ruleProcessor/ApplicationAccessLevelProcessorFacet.sol
+++ b/src/economic/ruleProcessor/ApplicationAccessLevelProcessorFacet.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.17;
 
 import {RuleProcessorDiamondLib as actionDiamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
-import {AppRuleDataFacet} from "src/economic/ruleStorage/AppRuleDataFacet.sol";
-import {IApplicationRules as Application} from "src/economic/ruleStorage/RuleDataInterfaces.sol";
+import {AppRuleDataFacet} from "../ruleStorage/AppRuleDataFacet.sol";
+import {IApplicationRules as Application} from "../ruleStorage/RuleDataInterfaces.sol";
 import {IRuleProcessorErrors, IAccessLevelErrors} from "../../interfaces/IErrors.sol";
 
 /**

--- a/src/economic/ruleProcessor/ApplicationPauseProcessorFacet.sol
+++ b/src/economic/ruleProcessor/ApplicationPauseProcessorFacet.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.17;
 
 import {ERC173} from "diamond-std/implementations/ERC173/ERC173.sol";
 import {RuleProcessorDiamondLib as actionDiamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
-import {AppRuleDataFacet} from "src/economic/ruleStorage/AppRuleDataFacet.sol";
-import {IApplicationRules as ApplicationRuleStorage} from "src/economic/ruleStorage/RuleDataInterfaces.sol";
+import {AppRuleDataFacet} from "../ruleStorage/AppRuleDataFacet.sol";
+import {IApplicationRules as ApplicationRuleStorage} from "../ruleStorage/RuleDataInterfaces.sol";
 import {IPauseRuleErrors} from "../../interfaces/IErrors.sol";
-import "src/data/PauseRule.sol";
-import "src/application/IAppManager.sol";
+import "../../data/PauseRule.sol";
+import "../../application/IAppManager.sol";
 
 /**
  * @title Application Pause Processor Facet

--- a/src/economic/ruleProcessor/ApplicationRiskProcessorFacet.sol
+++ b/src/economic/ruleProcessor/ApplicationRiskProcessorFacet.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.17;
 
 import {RuleProcessorDiamondLib as actionDiamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
-import {AppRuleDataFacet} from "src/economic/ruleStorage/AppRuleDataFacet.sol";
-import {IApplicationRules as ApplicationRuleStorage} from "src/economic/ruleStorage/RuleDataInterfaces.sol";
-import {IRuleProcessorErrors, IRiskErrors} from "src/interfaces/IErrors.sol";
+import {AppRuleDataFacet} from "../ruleStorage/AppRuleDataFacet.sol";
+import {IApplicationRules as ApplicationRuleStorage} from "../ruleStorage/RuleDataInterfaces.sol";
+import {IRuleProcessorErrors, IRiskErrors} from "../../interfaces/IErrors.sol";
 
 /**
  * @title Risk Score Processor Facet Contract

--- a/src/economic/ruleProcessor/ERC20TaggedRuleProcessorFacet.sol
+++ b/src/economic/ruleProcessor/ERC20TaggedRuleProcessorFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import {ERC173} from "diamond-std/implementations/ERC173/ERC173.sol";
 import {RuleProcessorDiamondLib as Diamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
 import {TaggedRuleDataFacet} from "../ruleStorage/TaggedRuleDataFacet.sol";

--- a/src/economic/ruleProcessor/RuleApplicationValidationFacet.sol
+++ b/src/economic/ruleProcessor/RuleApplicationValidationFacet.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.17;
 
 import {RuleProcessorDiamondLib as Diamond, RuleDataStorage} from "./RuleProcessorDiamondLib.sol";
-import {FeeRuleDataFacet} from "src/economic/ruleStorage/FeeRuleDataFacet.sol";
-import {TaggedRuleDataFacet} from "src/economic/ruleStorage/TaggedRuleDataFacet.sol";
-import {RuleDataFacet} from "src/economic/ruleStorage/RuleDataFacet.sol";
-import {AppRuleDataFacet} from "src/economic/ruleStorage/AppRuleDataFacet.sol";
+import {FeeRuleDataFacet} from "../ruleStorage/FeeRuleDataFacet.sol";
+import {TaggedRuleDataFacet} from "../ruleStorage/TaggedRuleDataFacet.sol";
+import {RuleDataFacet} from "../ruleStorage/RuleDataFacet.sol";
+import {AppRuleDataFacet} from "../ruleStorage/AppRuleDataFacet.sol";
 import {IFeeRules as Fee, ITaggedRules as TaggedRules, INonTaggedRules as NonTaggedRules} from "../ruleStorage/RuleDataInterfaces.sol";
-import "src/economic/ruleStorage/RuleStorageCommonLib.sol";
-import "src/data/PauseRule.sol";
-import "src/application/IAppManager.sol";
+import "../ruleStorage/RuleStorageCommonLib.sol";
+import "../../data/PauseRule.sol";
+import "../../application/IAppManager.sol";
 import "forge-std/console.sol";
 
 /**

--- a/src/economic/ruleStorage/FeeRuleDataFacet.sol
+++ b/src/economic/ruleStorage/FeeRuleDataFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../AppAdministratorOnly.sol";
 import {RuleStoragePositionLib as Storage} from "./RuleStoragePositionLib.sol";
 import {IFeeRules as Fee} from "./RuleDataInterfaces.sol";

--- a/src/economic/ruleStorage/RuleDataFacet.sol
+++ b/src/economic/ruleStorage/RuleDataFacet.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../AppAdministratorOnly.sol";
 import {RuleStoragePositionLib as Storage} from "./RuleStoragePositionLib.sol";
 import {INonTaggedRules as NonTaggedRules} from "./RuleDataInterfaces.sol";

--- a/src/example/ApplicationAppManager.sol
+++ b/src/example/ApplicationAppManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import {AppManager} from "src/application/AppManager.sol";
+import {AppManager} from "../application/AppManager.sol";
 
 /**
  * @title Application specific app manager

--- a/src/example/ApplicationERC721.sol
+++ b/src/example/ApplicationERC721.sol
@@ -111,7 +111,7 @@ contract ApplicationERC721
     /// Contract Owner or App Administrator Minting 
     /**
      * @dev Function mints new a new token to caller with tokenId incremented by 1 from previous minted token at mintPrice.
-     * @notice Uncomment this function and comment out safeMint() above. This allows for user minting at fixed price.
+     * @notice Uncomment this function and comment out safeMint() above. This allows for app-administrator-or-owner-only minting.
      * @param to Address of recipient
      */
       function safeMint(address to) public payable override whenNotPaused appAdministratorOrOwnerOnly(appManagerAddress) {

--- a/src/example/ApplicationERC721.sol
+++ b/src/example/ApplicationERC721.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.17;
 
 import "../token/ProtocolERC721.sol";
-import "../economic/AppAdministratorOrOwnerOnly.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
@@ -11,22 +10,18 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * @notice This is an example implementation that App Devs should use.
  * During deployment, _handlerAddress = ERC721Handler contract address
  *                    _appManagerAddress = AppManager contract address
- * @dev This contract contains 3 different safeMint implementations: priced minting, app-administrator-only minting, and app-administrator-or-owner-only minting.
- * The safeMint implementation enabled by default is the app-administrator-or-owner-only, but it is possible to choose any of the other 2 options, or even creating  
- * a different safeMint implementation. However, bare in mind that only one safeMint function can exist at a time in the contract unless polymorphism is used. To
- * select the desired safeMint function, simply comment out and/or delete any safeMint implementations and variable that are not going to be used, and make sure
- * that the one implementation you chose and its variables are enabled (not commented out).
+ * @dev This contract contains 3 different safeMint implementations: priced minting, free minting and app-administrator-only minting. The safeMint is by default
+ * restricted to app-administrators or contract-owner, but it is possible to override such configuration and choose any of the other 3 options in here, or even   
+ * creating a different safeMint implementation. However, bare in mind that only one safeMint function can exist at a time in the contract unless polymorphism is 
+ * used. If it is wished to override the default minting restriction from app-administrators or contract-owners, select the desired safeMint function by simply 
+ * uncommenting the desired implementations and its variables, or write your own implementation that overrides the default safeMint function.
  */
 
-contract ApplicationERC721 
-    is 
-    ProtocolERC721
-    ,AppAdministratorOrOwnerOnly
-    {
+contract ApplicationERC721 is ProtocolERC721 {
 
     /// Optional Function Variables and Errors. Uncomment these if using option functions:
-    using Counters for Counters.Counter;
-    Counters.Counter private _tokenIdCounter;
+    // using Counters for Counters.Counter;
+    // Counters.Counter private _tokenIdCounter;
 
     /// Mint Fee
     // uint256 public mintPrice; /// Chain Native Token price used for priced minting.
@@ -108,15 +103,16 @@ contract ApplicationERC721
     //     _safeMint(to, tokenId);
     // }
 
-    /// Contract Owner or App Administrator Minting 
+    /// Free Mint (Not Recommended)
     /**
-     * @dev Function mints new a new token to caller with tokenId incremented by 1 from previous minted token at mintPrice.
-     * @notice Uncomment this function and comment out safeMint() above. This allows for app-administrator-or-owner-only minting.
+     * @dev Function mints new a new token to anybody. Don't enabled this function if you are not sure about what you're doing.
+     * @notice To use, uncomment this function and comment out safeMint() above. This allows everybody to mint for free.
      * @param to Address of recipient
      */
-      function safeMint(address to) public payable override whenNotPaused appAdministratorOrOwnerOnly(appManagerAddress) {
-        uint256 tokenId = _tokenIdCounter.current();
-        _tokenIdCounter.increment();
-        _safeMint(to, tokenId);
-    }
+    // function safeMint(address to) public payable override whenNotPaused{
+    //     uint256 tokenId = _tokenIdCounter.current();
+    //     _tokenIdCounter.increment();
+    //     _safeMint(to, tokenId);
+    // }
+
 }

--- a/src/example/ApplicationERC721.sol
+++ b/src/example/ApplicationERC721.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 
 import "../token/ProtocolERC721.sol";
 import "../economic/AppAdministratorOrOwnerOnly.sol";
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title ApplicationERC721

--- a/src/example/ApplicationERC721UProxy.sol
+++ b/src/example/ApplicationERC721UProxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/proxy//ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts/proxy//ERC1967/ERC1967Proxy.sol";
 
 /**
  * @title ApplicationERC721UProxy

--- a/src/example/OracleAllowed.sol
+++ b/src/example/OracleAllowed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title Example On-chain Allow-List Oracle

--- a/src/example/OracleRestricted.sol
+++ b/src/example/OracleRestricted.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @title Example On-chain Restrict-List Oracle

--- a/src/example/application/ApplicationHandler.sol
+++ b/src/example/application/ApplicationHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "src/application/ProtocolApplicationHandler.sol";
+import "../../application/ProtocolApplicationHandler.sol";
 
 /**
  * @title AppManager Contract

--- a/src/example/pricing/CustomERC20Pricing.sol
+++ b/src/example/pricing/CustomERC20Pricing.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import {IApplicationEvents} from "../../interfaces/IEvents.sol";
 import "../../pricing/IProtocolERC20Pricing.sol";
 import "../../economic/AppAdministratorOnly.sol";

--- a/src/example/pricing/CustomERC721Pricing.sol
+++ b/src/example/pricing/CustomERC721Pricing.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import {IApplicationEvents} from "../../interfaces/IEvents.sol";
 import "../../pricing/IProtocolERC721Pricing.sol";
 import "../../economic/AppAdministratorOnly.sol";

--- a/src/example/script/AppManager.s.sol
+++ b/src/example/script/AppManager.s.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import {ApplicationAppManager} from "src/example/ApplicationAppManager.sol";
-import "src/example/application/ApplicationHandler.sol";
+import {ApplicationAppManager} from "../ApplicationAppManager.sol";
+import "../application/ApplicationHandler.sol";
 
 /**
  * @title App Manager Deployment Script

--- a/src/example/script/ApplicationCoin.s.sol
+++ b/src/example/script/ApplicationCoin.s.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/ApplicationERC20.sol";
-import "src/application/IAppManager.sol";
+import "../ApplicationERC20.sol";
+import "../../application/IAppManager.sol";
 
 /**
  * @title This is the deployment script for the Application Coin ERC20.

--- a/src/example/script/ApplicationDeployAll.s.sol
+++ b/src/example/script/ApplicationDeployAll.s.sol
@@ -2,20 +2,20 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/ApplicationERC20Handler.sol";
-import {ApplicationERC721Handler} from "src/example/ApplicationERC721Handler.sol";
-import "src/example/ApplicationERC20.sol";
-import {ApplicationERC721} from "src/example/ApplicationERC721.sol";
-import {ApplicationAppManager} from "src/example/ApplicationAppManager.sol";
-import "src/example/application/ApplicationHandler.sol";
-import "src/example/OracleRestricted.sol";
-import "src/example/OracleAllowed.sol";
-import "src/example/pricing/ApplicationERC20Pricing.sol";
-import "src/example/pricing/ApplicationERC721Pricing.sol";
-import "src/example/staking/ERC20Staking.sol";
-import "src/example/staking/ERC20AutoMintStaking.sol";
-import "src/example/staking/ERC721Staking.sol";
-import "src/example/staking/ERC721AutoMintStaking.sol";
+import "../ApplicationERC20Handler.sol";
+import {ApplicationERC721Handler} from "../ApplicationERC721Handler.sol";
+import "../ApplicationERC20.sol";
+import {ApplicationERC721} from "../ApplicationERC721.sol";
+import {ApplicationAppManager} from "../ApplicationAppManager.sol";
+import "../application/ApplicationHandler.sol";
+import "../OracleRestricted.sol";
+import "../OracleAllowed.sol";
+import "../pricing/ApplicationERC20Pricing.sol";
+import "../pricing/ApplicationERC721Pricing.sol";
+import "../staking/ERC20Staking.sol";
+import "../staking/ERC20AutoMintStaking.sol";
+import "../staking/ERC721Staking.sol";
+import "../staking/ERC721AutoMintStaking.sol";
 
 /**
  * @title Application Deploy All Script

--- a/src/example/script/ApplicationERC721.s.sol
+++ b/src/example/script/ApplicationERC721.s.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/ApplicationERC721.sol";
-import "src/application/IAppManager.sol";
-import {ApplicationERC721Handler} from "src/example/ApplicationERC721Handler.sol";
+import "../ApplicationERC721.sol";
+import "../../application/IAppManager.sol";
+import {ApplicationERC721Handler} from "../ApplicationERC721Handler.sol";
 
 /**
  * @title This is the deployment script for the Application NFT.

--- a/src/example/script/ApplicationERC721U.s.sol
+++ b/src/example/script/ApplicationERC721U.s.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/ApplicationERC721U.sol";
-import "src/example/ApplicationERC721UProxy.sol";
-import "src/application/IAppManager.sol";
-import {ApplicationERC721Handler} from "src/example/ApplicationERC721Handler.sol";
+import "../ApplicationERC721U.sol";
+import "../ApplicationERC721UProxy.sol";
+import "../../application/IAppManager.sol";
+import {ApplicationERC721Handler} from "../ApplicationERC721Handler.sol";
 
 /**
  * @title This is the deployment script for the ApplicationERC721U.

--- a/src/example/script/ERC20AutoMintStaking.s.sol
+++ b/src/example/script/ERC20AutoMintStaking.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/staking/ERC20AutoMintStaking.sol";
+import "../staking/ERC20AutoMintStaking.sol";
 
 /**
  * @title Create a ERC20 Auto Mint Staking Contract

--- a/src/example/script/ERC20Staking.s.sol
+++ b/src/example/script/ERC20Staking.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/staking/ERC20Staking.sol";
+import "../staking/ERC20Staking.sol";
 
 /**
  * @title Create a ERC20 Staking Contract

--- a/src/example/script/ERC721AutoMintStaking.s.sol
+++ b/src/example/script/ERC721AutoMintStaking.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/staking/ERC721AutoMintStaking.sol";
+import "../staking/ERC721AutoMintStaking.sol";
 
 /**
  * @title Create a ERC721 Auto Mint Staking Contract

--- a/src/example/script/ERC721Staking.s.sol
+++ b/src/example/script/ERC721Staking.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/staking/ERC721Staking.sol";
+import "../staking/ERC721Staking.sol";
 
 /**
  * @title Create a ERC721 Staking Contract

--- a/src/example/script/OracleAllowed.s.sol
+++ b/src/example/script/OracleAllowed.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/OracleAllowed.sol";
+import "../OracleAllowed.sol";
 
 /**
  * @title Create the Allow Oracle

--- a/src/example/script/OracleRestricted.s.sol
+++ b/src/example/script/OracleRestricted.s.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Script.sol";
-import "src/example/OracleRestricted.sol";
+import "../OracleRestricted.sol";
 
 /**
  * @title Create the Restricted Oracle

--- a/src/example/staking/ERC20AutoMintStaking.sol
+++ b/src/example/staking/ERC20AutoMintStaking.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.17;
 
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../../staking/IERC20Staking.sol";
 import "../../economic/AppAdministratorOnly.sol";
 import "../../application/IAppManager.sol";

--- a/src/example/staking/ERC20Staking.sol
+++ b/src/example/staking/ERC20Staking.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.17;
 
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../../staking/IERC20Staking.sol";
 import "../../economic/AppAdministratorOnly.sol";
 import "../../application/IAppManager.sol";

--- a/src/example/staking/ERC721AutoMintStaking.sol
+++ b/src/example/staking/ERC721AutoMintStaking.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.17;
 
-import "openzeppelin-contracts/contracts/token/ERC721/IERC721Receiver.sol";
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../../staking/IERC721Staking.sol";
 import "../../economic/AppAdministratorOnly.sol";
 import "../../application/IAppManager.sol";

--- a/src/example/staking/ERC721Staking.sol
+++ b/src/example/staking/ERC721Staking.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.17;
 
-import "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/IERC721Receiver.sol";
-import "openzeppelin-contracts/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 import "../../staking/IERC721Staking.sol";
 import "../../economic/AppAdministratorOnly.sol";
 import "../../application/IAppManager.sol";

--- a/src/pricing/ProtocolERC20Pricing.sol
+++ b/src/pricing/ProtocolERC20Pricing.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165Checker.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "./IProtocolERC20Pricing.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 

--- a/src/pricing/ProtocolERC721Pricing.sol
+++ b/src/pricing/ProtocolERC721Pricing.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165Checker.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import "./IProtocolERC721Pricing.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 

--- a/src/staking/IERC20Staking.sol
+++ b/src/staking/IERC20Staking.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.8.17;
  * the TIME_UNITS_TO_SECS 'constant'
  */
 
-import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IStakingErrors } from "../interfaces/IErrors.sol";
 
 //// add context contract

--- a/src/staking/IERC721Staking.sol
+++ b/src/staking/IERC721Staking.sol
@@ -8,8 +8,8 @@ pragma solidity ^0.8.17;
  * the TIME_UNITS_TO_SECS 'constant'
  */
 
-import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 
 import { IStakingErrors, IERC721StakingErrors } from "../interfaces/IErrors.sol";
 

--- a/src/token/IAdminWithdrawalRuleCapable.sol
+++ b/src/token/IAdminWithdrawalRuleCapable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
-import "openzeppelin-contracts/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @title Admin Withdrawal Capable

--- a/src/token/IProtocolERC721Handler.sol
+++ b/src/token/IProtocolERC721Handler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
-import "src/economic/ruleProcessor/ActionEnum.sol";
+import "../economic/ruleProcessor/ActionEnum.sol";
 
 /**
  * @title Asset Handler Interface

--- a/src/token/ProtocolERC20.sol
+++ b/src/token/ProtocolERC20.sol
@@ -9,8 +9,8 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20FlashMint.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 import {IZeroAddressError, IProtocolERC20Errors} from "../interfaces/IErrors.sol";
 import "./ProtocolTokenCommon.sol";
-import "src/token/ProtocolERC20Handler.sol";
-import "src/economic/AppAdministratorOnly.sol";
+import "./ProtocolERC20Handler.sol";
+import "../economic/AppAdministratorOnly.sol";
 
 /**
  * @title ERC20 Base Contract

--- a/src/token/ProtocolERC20.sol
+++ b/src/token/ProtocolERC20.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
-import "openzeppelin-contracts/contracts/security/Pausable.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20Burnable.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/extensions/ERC20FlashMint.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20FlashMint.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 import {IZeroAddressError, IProtocolERC20Errors} from "../interfaces/IErrors.sol";
 import "./ProtocolTokenCommon.sol";

--- a/src/token/ProtocolERC20Handler.sol
+++ b/src/token/ProtocolERC20Handler.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import "./data/Fees.sol";
-import {IZeroAddressError, IAssetHandlerErrors} from "src/interfaces/IErrors.sol";
+import {IZeroAddressError, IAssetHandlerErrors} from "../interfaces/IErrors.sol";
 import "./ProtocolHandlerCommon.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/src/token/ProtocolERC20Handler.sol
+++ b/src/token/ProtocolERC20Handler.sol
@@ -3,13 +3,13 @@ pragma solidity 0.8.17;
 
 /// TODO Create a wizard that creates custom versions of this contract for each implementation.
 
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165Checker.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 
 import "./data/Fees.sol";
 import {IZeroAddressError, IAssetHandlerErrors} from "src/interfaces/IErrors.sol";
 import "./ProtocolHandlerCommon.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 /**
  * @title Example ApplicationERC20Handler Contract

--- a/src/token/ProtocolERC721.sol
+++ b/src/token/ProtocolERC721.sol
@@ -8,8 +8,8 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "./ProtocolTokenCommon.sol";
-import "src/economic/AppAdministratorOnly.sol";
-import "src/token/IProtocolERC721Handler.sol";
+import "../economic/AppAdministratorOnly.sol";
+import "../token/IProtocolERC721Handler.sol";
 
 /**
  * @title ERC721 Base Contract

--- a/src/token/ProtocolERC721.sol
+++ b/src/token/ProtocolERC721.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/utils/Counters.sol";
-import "openzeppelin-contracts/contracts/security/Pausable.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721Burnable.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "./ProtocolTokenCommon.sol";
 import "src/economic/AppAdministratorOnly.sol";
 import "src/token/IProtocolERC721Handler.sol";

--- a/src/token/ProtocolERC721.sol
+++ b/src/token/ProtocolERC721.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "./ProtocolTokenCommon.sol";
 import "../economic/AppAdministratorOnly.sol";
+import "../economic/AppAdministratorOrOwnerOnly.sol";
 import "../token/IProtocolERC721Handler.sol";
 
 /**
@@ -17,7 +18,7 @@ import "../token/IProtocolERC721Handler.sol";
  * @notice This is the base contract for all protocol ERC721s
  */
 
-contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, Pausable, ProtocolTokenCommon {
+contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, Pausable, ProtocolTokenCommon ,AppAdministratorOrOwnerOnly {
     using Counters for Counters.Counter;
     address public handlerAddress;
     IProtocolERC721Handler handler;
@@ -93,7 +94,7 @@ contract ProtocolERC721 is ERC721Burnable, ERC721URIStorage, ERC721Enumerable, P
      * Function is payable for child contracts to override with priced mint function.
      * @param to Address of recipient
      */
-    function safeMint(address to) public payable virtual whenNotPaused {
+    function safeMint(address to) public payable virtual whenNotPaused appAdministratorOrOwnerOnly(appManagerAddress){
         uint256 tokenId = _tokenIdCounter.current();
         _tokenIdCounter.increment();
         _safeMint(to, tokenId);

--- a/src/token/ProtocolERC721Handler.sol
+++ b/src/token/ProtocolERC721Handler.sol
@@ -10,9 +10,9 @@ pragma solidity 0.8.17;
  *      Any rule handlers may be updated by modifying this contract, redeploying, and pointing the ERC721 to the new version.
  * @notice This contract is the interaction point for the application ecosystem to the protocol
  */
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
-import "openzeppelin-contracts/contracts/utils/introspection/ERC165.sol";
-import "openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "./ProtocolHandlerCommon.sol";
 
 contract ProtocolERC721Handler is Ownable, ProtocolHandlerCommon, IAdminWithdrawalRuleCapable, ERC165 {

--- a/src/token/ProtocolERC721U.sol
+++ b/src/token/ProtocolERC721U.sol
@@ -10,8 +10,8 @@ import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin-upgradeable/contracts/utils/CountersUpgradeable.sol";
-import "src/token/IProtocolERC721Handler.sol";
-import "src/token/ProtocolTokenCommonU.sol";
+import "./IProtocolERC721Handler.sol";
+import "./ProtocolTokenCommonU.sol";
 
 /**
  * @title ERC721 Upgradeable Protocol Contract

--- a/src/token/ProtocolERC721U.sol
+++ b/src/token/ProtocolERC721U.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/security/PausableUpgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/access/OwnableUpgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/utils/CountersUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/security/PausableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgradeable/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/utils/CountersUpgradeable.sol";
 import "src/token/IProtocolERC721Handler.sol";
 import "src/token/ProtocolTokenCommonU.sol";
 

--- a/src/token/ProtocolERC721Umin.sol
+++ b/src/token/ProtocolERC721Umin.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
 import "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
-import "src/token/IProtocolERC721Handler.sol";
-import "src/token/ProtocolTokenCommonU.sol";
+import "./IProtocolERC721Handler.sol";
+import "./ProtocolTokenCommonU.sol";
 
 /**
  * @title ERC721 Upgradeable Protocol Contract

--- a/src/token/ProtocolERC721Umin.sol
+++ b/src/token/ProtocolERC721Umin.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts-upgradeable/contracts/proxy/utils/Initializable.sol";
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin-upgradeable/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgradeable/contracts/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "src/token/IProtocolERC721Handler.sol";
 import "src/token/ProtocolTokenCommonU.sol";
 

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -5,15 +5,15 @@ import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IAssetHandlerErrors, IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 import {ITokenHandlerEvents} from "../interfaces/IEvents.sol";
-import "src/economic/ruleStorage/RuleCodeData.sol";
-import "src/economic/IRuleProcessor.sol";
-import "src/application/IAppManager.sol";
-import "src/pricing/IProtocolERC721Pricing.sol";
-import "src/pricing/IProtocolERC20Pricing.sol";
-import "src/economic/AppAdministratorOrOwnerOnly.sol";
-import "src/economic/AppAdministratorOnly.sol";
-import "src/application/IAppManagerUser.sol";
-import "src/token/IAdminWithdrawalRuleCapable.sol";
+import "../economic/ruleStorage/RuleCodeData.sol";
+import "../economic/IRuleProcessor.sol";
+import "../application/IAppManager.sol";
+import "../pricing/IProtocolERC721Pricing.sol";
+import "../pricing/IProtocolERC20Pricing.sol";
+import "../economic/AppAdministratorOrOwnerOnly.sol";
+import "../economic/AppAdministratorOnly.sol";
+import "../application/IAppManagerUser.sol";
+import "./IAdminWithdrawalRuleCapable.sol";
 
 /**
  * @title Protocol Handler Common

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "openzeppelin-contracts/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {IAssetHandlerErrors, IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 import {ITokenHandlerEvents} from "../interfaces/IEvents.sol";
 import "src/economic/ruleStorage/RuleCodeData.sol";

--- a/src/token/ProtocolTokenCommon.sol
+++ b/src/token/ProtocolTokenCommon.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "src/economic/AppAdministratorOnly.sol";
+import "../economic/AppAdministratorOnly.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 

--- a/src/token/ProtocolTokenCommonU.sol
+++ b/src/token/ProtocolTokenCommonU.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.17;
 
-import "src/economic/AppAdministratorOnlyU.sol";
+import "../economic/AppAdministratorOnlyU.sol";
 import {IApplicationEvents} from "../interfaces/IEvents.sol";
 import {IOwnershipErrors, IZeroAddressError} from "../interfaces/IErrors.sol";
 

--- a/src/token/data/Fees.sol
+++ b/src/token/data/Fees.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.17;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import {IApplicationEvents} from "../../interfaces/IEvents.sol";
 import {IInputErrors, ITagInputErrors, IOwnershipErrors, IZeroAddressError} from "../../interfaces/IErrors.sol";
-import "src/economic/AppAdministratorOnly.sol";
+import "../../economic/AppAdministratorOnly.sol";
 
 /**
  * @title Fees

--- a/src/token/data/Fees.sol
+++ b/src/token/data/Fees.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
-import "openzeppelin-contracts/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import {IApplicationEvents} from "../../interfaces/IEvents.sol";
 import {IInputErrors, ITagInputErrors, IOwnershipErrors, IZeroAddressError} from "../../interfaces/IErrors.sol";
 import "src/economic/AppAdministratorOnly.sol";

--- a/test/ApplicationERC721.t.sol
+++ b/test/ApplicationERC721.t.sol
@@ -204,7 +204,7 @@ contract ApplicationERC721Test is DiamondTestUtil, RuleProcessorDiamondTestUtil 
 
         ///make sure the maximum rule fail results in revert
         vm.stopPrank();
-        vm.startPrank(user1);
+        vm.startPrank(appAdministrator);
         // user1 mints to 6 total (limit)
         applicationNFT.safeMint(user1); /// Id 6
         applicationNFT.safeMint(user1); /// Id 7
@@ -213,9 +213,11 @@ contract ApplicationERC721Test is DiamondTestUtil, RuleProcessorDiamondTestUtil 
         applicationNFT.safeMint(user1); /// Id 10
 
         vm.stopPrank();
-        vm.startPrank(user2);
+        vm.startPrank(appAdministrator);
         applicationNFT.safeMint(user2);
         // transfer to user1 to exceed limit
+        vm.stopPrank();
+        vm.startPrank(user2);
         vm.expectRevert(0x24691f6b);
         applicationNFT.transferFrom(user2, user1, 3);
     }
@@ -793,7 +795,7 @@ contract ApplicationERC721Test is DiamondTestUtil, RuleProcessorDiamondTestUtil 
         vm.warp(Blocktime + 13 hours);
         /// mint tokens under supply limit
         vm.stopPrank();
-        vm.startPrank(user1);
+        vm.startPrank(defaultAdmin);
         applicationNFT.safeMint(user1);
         /// mint tokens to the cap
         applicationNFT.safeMint(user1);
@@ -801,12 +803,16 @@ contract ApplicationERC721Test is DiamondTestUtil, RuleProcessorDiamondTestUtil 
         vm.expectRevert();
         applicationNFT.safeMint(user1);
 
+        vm.stopPrank();
+        vm.startPrank(user1);
         applicationNFT.burn(10);
         /// move out of rule period
         vm.warp(Blocktime + 36 hours);
         /// burn tokens (should pass)
         applicationNFT.burn(11);
         /// mint
+        vm.stopPrank();
+        vm.startPrank(defaultAdmin);
         applicationNFT.safeMint(user1);
     }
 

--- a/test/ApplicationERC721Fuzz.t.sol
+++ b/test/ApplicationERC721Fuzz.t.sol
@@ -104,9 +104,9 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         address[] memory addressList = getUniqueAddresses(_addressIndex % ADDRESSES.length, 2);
         address randomUser = addressList[0];
         address randomUser2 = addressList[1];
+        applicationNFT.safeMint(randomUser);
         vm.stopPrank();
         vm.startPrank(randomUser);
-        applicationNFT.safeMint(randomUser);
         applicationNFT.transferFrom(randomUser, randomUser2, 0);
         assertEq(applicationNFT.balanceOf(randomUser), 0);
         assertEq(applicationNFT.balanceOf(randomUser2), 1);
@@ -120,15 +120,21 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         // vm.startPrank(randomUser);
         ///Mint and transfer tokenId 0
         applicationNFT.safeMint(randomUser);
+        vm.stopPrank();
+        vm.startPrank(randomUser);
         applicationNFT.transferFrom(randomUser, randomUser2, 0);
         ///Mint tokenId 1
+        vm.stopPrank();
+        vm.startPrank(defaultAdmin);
         applicationNFT.safeMint(randomUser);
         ///Test token burn of token 0 and token 1
+        vm.stopPrank();
+        vm.startPrank(randomUser);
         applicationNFT.burn(1);
         ///Switch to app administrator account for burn
-        // vm.stopPrank();
-        // vm.startPrank(randomUser2);
-        /// Burn appAdministrator token
+        vm.stopPrank();
+        vm.startPrank(randomUser2);
+        // Burn appAdministrator token
         applicationNFT.burn(0);
         ///Return to default admin account
         // vm.stopPrank();
@@ -1134,8 +1140,6 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         /// determine the maximum burn/mint amount for inital test
         uint256 maxVol = uint256(volLimit) / 1000;
         console.logUint(maxVol);
-        vm.stopPrank();
-        vm.startPrank(rich_user);
         /// make sure that transfer under the threshold works
         if (maxVol >= 1) {
             for (uint i = 0; i < maxVol - 1; i++) {
@@ -1152,14 +1156,24 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
             applicationNFT.safeMint(rich_user);
         }
         /// at vol limit
+        vm.stopPrank();
+        vm.startPrank(rich_user);
         if ((10000 / applicationNFT.totalSupply()) > volLimit) {
             vm.expectRevert();
             applicationNFT.burn(9);
         } else {
             applicationNFT.burn(9);
+            vm.stopPrank();
+            vm.startPrank(defaultAdmin);
             applicationNFT.safeMint(rich_user); // token 10
+            vm.stopPrank();
+            vm.startPrank(rich_user);
             applicationNFT.burn(10);
+            vm.stopPrank();
+            vm.startPrank(defaultAdmin);
             applicationNFT.safeMint(rich_user);
+            vm.stopPrank();
+            vm.startPrank(rich_user);
             applicationNFT.burn(11);
         }
     }

--- a/test/ApplicationERC721Fuzz.t.sol
+++ b/test/ApplicationERC721Fuzz.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
-import "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ApplicationERC20} from "../src/example/ApplicationERC20.sol";
 import {ApplicationERC721} from "src/example/ApplicationERC721.sol";
 import "../src/example/ApplicationAppManager.sol";

--- a/test/ApplicationERC721Fuzz.t.sol
+++ b/test/ApplicationERC721Fuzz.t.sol
@@ -116,8 +116,8 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         address[] memory addressList = getUniqueAddresses(_addressIndex % ADDRESSES.length, 2);
         address randomUser = addressList[0];
         address randomUser2 = addressList[1];
-        vm.stopPrank();
-        vm.startPrank(randomUser);
+        // vm.stopPrank();
+        // vm.startPrank(randomUser);
         ///Mint and transfer tokenId 0
         applicationNFT.safeMint(randomUser);
         applicationNFT.transferFrom(randomUser, randomUser2, 0);
@@ -126,13 +126,13 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         ///Test token burn of token 0 and token 1
         applicationNFT.burn(1);
         ///Switch to app administrator account for burn
-        vm.stopPrank();
-        vm.startPrank(randomUser2);
+        // vm.stopPrank();
+        // vm.startPrank(randomUser2);
         /// Burn appAdministrator token
         applicationNFT.burn(0);
         ///Return to default admin account
-        vm.stopPrank();
-        vm.startPrank(randomUser);
+        // vm.stopPrank();
+        // vm.startPrank(randomUser);
         assertEq(applicationNFT.balanceOf(randomUser), 0);
         assertEq(applicationNFT.balanceOf(randomUser2), 0);
     }
@@ -215,7 +215,7 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
 
         ///make sure the maximum rule fail results in revert
         vm.stopPrank();
-        vm.startPrank(user1);
+        vm.startPrank(appAdministrator);
         // user1 mints to 6 total (limit)
         applicationNFT.safeMint(user1); /// Id 6
         applicationNFT.safeMint(user1); /// Id 7
@@ -223,10 +223,12 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         applicationNFT.safeMint(user1); /// Id 9
         applicationNFT.safeMint(user1); /// Id 10
 
-        vm.stopPrank();
-        vm.startPrank(user2);
+        // vm.stopPrank();
+        // vm.startPrank(user2);
         applicationNFT.safeMint(user2);
         // transfer to user1 to exceed limit
+        vm.stopPrank();
+        vm.startPrank(user2);
         vm.expectRevert(0x24691f6b);
         applicationNFT.transferFrom(user2, user1, 3);
     }

--- a/test/ApplicationERC721Fuzz.t.sol
+++ b/test/ApplicationERC721Fuzz.t.sol
@@ -116,8 +116,6 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         address[] memory addressList = getUniqueAddresses(_addressIndex % ADDRESSES.length, 2);
         address randomUser = addressList[0];
         address randomUser2 = addressList[1];
-        // vm.stopPrank();
-        // vm.startPrank(randomUser);
         ///Mint and transfer tokenId 0
         applicationNFT.safeMint(randomUser);
         vm.stopPrank();
@@ -137,8 +135,6 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         // Burn appAdministrator token
         applicationNFT.burn(0);
         ///Return to default admin account
-        // vm.stopPrank();
-        // vm.startPrank(randomUser);
         assertEq(applicationNFT.balanceOf(randomUser), 0);
         assertEq(applicationNFT.balanceOf(randomUser2), 0);
     }
@@ -229,8 +225,6 @@ contract ApplicationERC721FuzzTest is DiamondTestUtil, RuleProcessorDiamondTestU
         applicationNFT.safeMint(user1); /// Id 9
         applicationNFT.safeMint(user1); /// Id 10
 
-        // vm.stopPrank();
-        // vm.startPrank(user2);
         applicationNFT.safeMint(user2);
         // transfer to user1 to exceed limit
         vm.stopPrank();

--- a/test/ERC721AutoMintStaking.t.sol
+++ b/test/ERC721AutoMintStaking.t.sol
@@ -257,23 +257,27 @@ contract ERC721AutoMintStakingTest is DiamondTestUtil, RuleProcessorDiamondTestU
         assertEq(applicationNFT.balanceOf(user2), 2);
         assertEq(applicationNFT.balanceOf(user3), 2);
 
+        applicationNFT2.safeMint(user1);
         vm.stopPrank();
         vm.startPrank(user1);
-        applicationNFT2.safeMint(user1);
         applicationNFT.approve(address(stakingContract), 0);
         applicationNFT.approve(address(stakingContract), 1);
         applicationNFT2.approve(address(stakingContract), 0);
 
         vm.stopPrank();
-        vm.startPrank(user2);
+        vm.startPrank(defaultAdmin);
         applicationNFT2.safeMint(user2);
+        vm.stopPrank();
+        vm.startPrank(user2);
         applicationNFT.approve(address(stakingContract), 2);
         applicationNFT.approve(address(stakingContract), 3);
         applicationNFT2.approve(address(stakingContract), 1);
 
         vm.stopPrank();
-        vm.startPrank(user3);
+        vm.startPrank(defaultAdmin);
         applicationNFT2.safeMint(user3);
+        vm.stopPrank();
+        vm.startPrank(user3);
         applicationNFT.approve(address(stakingContract), 4);
         applicationNFT.approve(address(stakingContract), 5);
         applicationNFT2.approve(address(stakingContract), 2);

--- a/test/ERC721Staking.t.sol
+++ b/test/ERC721Staking.t.sol
@@ -253,23 +253,27 @@ contract ERC721StakingTest is DiamondTestUtil, RuleProcessorDiamondTestUtil {
         assertEq(applicationNFT.balanceOf(user2), 2);
         assertEq(applicationNFT.balanceOf(user3), 2);
 
+        applicationNFT2.safeMint(user1);
         vm.stopPrank();
         vm.startPrank(user1);
-        applicationNFT2.safeMint(user1);
         applicationNFT.approve(address(stakingContract), 0);
         applicationNFT.approve(address(stakingContract), 1);
         applicationNFT2.approve(address(stakingContract), 0);
 
         vm.stopPrank();
-        vm.startPrank(user2);
+        vm.startPrank(defaultAdmin);
         applicationNFT2.safeMint(user2);
+        vm.stopPrank();
+        vm.startPrank(user2);
         applicationNFT.approve(address(stakingContract), 2);
         applicationNFT.approve(address(stakingContract), 3);
         applicationNFT2.approve(address(stakingContract), 1);
 
         vm.stopPrank();
-        vm.startPrank(user3);
+        vm.startPrank(defaultAdmin);
         applicationNFT2.safeMint(user3);
+        vm.stopPrank();
+        vm.startPrank(user3);
         applicationNFT.approve(address(stakingContract), 4);
         applicationNFT.approve(address(stakingContract), 5);
         applicationNFT2.approve(address(stakingContract), 2);


### PR DESCRIPTION
Changes were made to make the repo npm-package compatible and to address issue 16 from the audit. The main changes were:

- Example ERC721 now has minting restricted to app administrator or contract owner by default (Fix for issue 16 from audit).
- Tests were fixed to accommodate for this new version of ApplicationERC721 example.
- Absolute paths were migrated to relative paths.
- One unnecessary import was removed.
- openzeppelin-contracts was replaced for @openzeppelin to make it npm compatible out of the box.
