### PR TITLE
added to_relative script to installation of the package

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,8 +14,8 @@ eth-rpc-url = 'http://172.20.0.2:10002'
 
 remappings = ["forge-std/=lib/forge-std/src/",
     "ds-test/=lib/forge-std/lib/ds-test/src/",
-    "@openzeppelin/=lib/openzeppelin-contracts/",
-"@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
-"diamond-std/=lib/diamond-std/",]
+    "@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/",
+    "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/",
+    "diamond-std/=lib/diamond-std/",]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "prettier-plugin-solidity": "^1.1.1"
   },
   "name": "@thrackle-io/rules-protocol-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set of contracts to easily start an application in rules protocol",
   "dependencies": {
     "@openzeppelin/contracts": "4.9",
@@ -23,11 +23,12 @@
     "src/economic/AppAdministratorOnlyU.sol",
     "src/economic/ruleStorage/RuleCodeData.sol",
     "src/economic/ruleProcessor/ActionEnum.sol",
-    "unpack.sh"
+    "unpack.sh",
+    "to_relative.sh"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "chmod +x unpack.sh",
+    "install": "chmod +x unpack.sh to_relative.sh & ./to_relative.sh",
     "postinstall": "./unpack.sh"
   },
   "repository": {

--- a/src/token/IProtocolERC721UMin.sol
+++ b/src/token/IProtocolERC721UMin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/IERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721EnumerableUpgradeable.sol";
 
 /**
  * @title  Upgradeable ERC721 Protocol Interface Minimal implementation model

--- a/to_relative.sh
+++ b/to_relative.sh
@@ -13,7 +13,7 @@ for dir in "${directories[@]}"; do
         if [ -f "$file" ]; then
              echo "${file}"
             # Replace the old string with the new string and overwrite the file
-            sed -i "" 's%openzeppelin-contracts-upgradeable/%@openzeppelin/contracts-upgradeable/%g' "$file"
+            sed -i "" 's%openzeppelin-contracts-upgradeable/contracts/%@openzeppelin/contracts-upgradeable/%g' "$file"
             sed -i "" 's%openzeppelin-contracts%@openzeppelin%g' "$file"
             sed -i "" 's%@openzeppelin-upgradeable/contracts/%@openzeppelin/contracts-upgradeable/%g' "$file"
             # echo "Replaced openzeppelin-contracts"


### PR DESCRIPTION
- Minor fixes in the `to_relative.sh` script
- `to_relative.sh` script now runs as part of the installation process for the package to make sure current issue won't happen again.
- Even though the issue would be corrected at installation time in the clients machine, the script was run to fix current issue, so we don't have the wrong import style in Tron.
- The package.json was updated to now point to version 1.0.1 so it is ready to publish.