### PR TITLE
version updated to 1.0.1 and some minor fixes

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,7 @@ eth-rpc-url = 'http://172.20.0.2:10002'
 remappings = ["forge-std/=lib/forge-std/src/",
     "ds-test/=lib/forge-std/lib/ds-test/src/",
     "@openzeppelin/=lib/openzeppelin-contracts/",
-"@openzeppelin-upgradeable/=lib/openzeppelin-contracts-upgradeable/",
-"diamond-std/=lib/diamond-std/",]
+    "@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts",
+    "diamond-std/=lib/diamond-std/",]
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "prettier-plugin-solidity": "^1.1.1"
   },
   "name": "@thrackle-io/rules-protocol-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set of contracts to easily start an application in rules protocol",
   "dependencies": {
     "@openzeppelin/contracts": "4.9",
@@ -23,11 +23,12 @@
     "src/economic/AppAdministratorOnlyU.sol",
     "src/economic/ruleStorage/RuleCodeData.sol",
     "src/economic/ruleProcessor/ActionEnum.sol",
-    "unpack.sh"
+    "unpack.sh",
+    "to_relative.sh"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "install": "chmod +x unpack.sh",
+    "install": "chmod +x unpack.sh to_relative.sh & ./to_relative.sh",
     "postinstall": "./unpack.sh"
   },
   "repository": {

--- a/src/application/AppManager.sol
+++ b/src/application/AppManager.sol
@@ -28,7 +28,7 @@ import "../token/ProtocolTokenCommon.sol";
  * @notice This contract is the permissions contract
  */
 contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
-    string private constant VERSION ="1.0.0";
+    string private constant VERSION="1.0.1";
     using ERC165Checker for address;
     bytes32 constant APP_ADMIN_ROLE = keccak256("APP_ADMIN_ROLE");
     bytes32 constant ACCESS_TIER_ADMIN_ROLE = keccak256("ACCESS_TIER_ADMIN_ROLE");

--- a/src/application/ProtocolApplicationHandler.sol
+++ b/src/application/ProtocolApplicationHandler.sol
@@ -18,7 +18,7 @@ import "../economic/RuleAdministratorOnly.sol";
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
 contract ProtocolApplicationHandler is Ownable, RuleAdministratorOnly, IApplicationHandlerEvents, IInputErrors, IZeroAddressError {
-    string private constant VERSION="1.0.0";
+    string private constant VERSION="1.0.1";
     AppManager appManager;
     address public appManagerAddress;
     IRuleProcessor immutable ruleProcessor;

--- a/src/data/DataModule.sol
+++ b/src/data/DataModule.sol
@@ -14,7 +14,7 @@ import {IAppManager} from "../application/IAppManager.sol";
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
 abstract contract DataModule is IDataModule, Ownable, IOwnershipErrors, IZeroAddressError {
-    string private constant VERSION="1.0.0";
+    string private constant VERSION="1.0.1";
     ///Data Module
     address public dataModuleAppManagerAddress;
     address newOwner; // This is used for data contract migration

--- a/src/pricing/ProtocolERC20Pricing.sol
+++ b/src/pricing/ProtocolERC20Pricing.sol
@@ -13,7 +13,7 @@ import {IApplicationEvents} from "../interfaces/IEvents.sol";
  * @dev This contract doesn't allow any marketplace operations.
  */
 contract ProtocolERC20Pricing is Ownable, IApplicationEvents, IProtocolERC20Pricing {
-    string private constant VERSION="1.0.0";
+    string private constant VERSION="1.0.1";
     
     mapping(address => uint256) public tokenPrices;
 

--- a/src/pricing/ProtocolERC721Pricing.sol
+++ b/src/pricing/ProtocolERC721Pricing.sol
@@ -13,7 +13,7 @@ import {IApplicationEvents} from "../interfaces/IEvents.sol";
  * @dev This contract allows for setting prices on entire collections or by tokenId
  */
 contract ProtocolERC721Pricing is Ownable, IApplicationEvents, IProtocolERC721Pricing {
-    string private constant VERSION="1.0.0";
+    string private constant VERSION="1.0.1";
     using ERC165Checker for address;
 
     mapping(address => mapping(uint256 => uint256)) public nftPrice;

--- a/src/token/IProtocolERC721UMin.sol
+++ b/src/token/IProtocolERC721UMin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.17;
 
-import "openzeppelin-contracts-upgradeable/contracts/token/ERC721/extensions/IERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721EnumerableUpgradeable.sol";
 
 /**
  * @title  Upgradeable ERC721 Protocol Interface Minimal implementation model

--- a/src/token/ProtocolHandlerCommon.sol
+++ b/src/token/ProtocolHandlerCommon.sol
@@ -23,7 +23,7 @@ import "./IAdminWithdrawalRuleCapable.sol";
  */
 
 abstract contract ProtocolHandlerCommon is IAppManagerUser, IOwnershipErrors, IZeroAddressError, ITokenHandlerEvents, IAssetHandlerErrors, AppAdministratorOrOwnerOnly {
-    string private constant VERSION="1.0.0";
+    string private constant VERSION="1.0.1";
     address private newAppManagerAddress;
     address public appManagerAddress;
     IRuleProcessor ruleProcessor;

--- a/src/token/data/Fees.sol
+++ b/src/token/data/Fees.sol
@@ -12,7 +12,7 @@ import "../../economic/AppAdministratorOnly.sol";
  * @author @ShaneDuncan602, @oscarsernarosero, @TJ-Everett
  */
 contract Fees is Ownable, IApplicationEvents, IInputErrors, ITagInputErrors, IOwnershipErrors, IZeroAddressError, AppAdministratorOnly {
-    string private constant VERSION="1.0.0";
+    string private constant VERSION="1.0.1";
     int256 defaultFee;
     mapping(bytes32 => Fee) feesByTag;
     uint256 feeTotal;

--- a/test/ApplicationAppManager.t.sol
+++ b/test/ApplicationAppManager.t.sol
@@ -53,13 +53,13 @@ contract ApplicationAppManagerTest is TestCommon {
 
     function testAppManagerAndHandlerVersions() public {
         string memory version = applicationAppManager.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
         version = applicationHandler.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
         version = applicationAppManager2.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
         version = applicationHandler2.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
     }
 
     ///---------------DEFAULT ADMIN--------------------

--- a/test/ApplicationERC20.t.sol
+++ b/test/ApplicationERC20.t.sol
@@ -50,7 +50,7 @@ contract ApplicationERC20Test is TestCommon {
 
     function testERC20AndHandlerVersions() public {
         string memory version = applicationCoinHandler.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
     }
 
     /// Test balance

--- a/test/ApplicationERC721.t.sol
+++ b/test/ApplicationERC721.t.sol
@@ -38,7 +38,7 @@ contract ApplicationERC721Test is TestCommon {
 
     function testERC721AndHandlerVersions() public {
         string memory version = applicationNFTHandler.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
     }
 
     function testMint() public {

--- a/test/ERC721Pricing.t.sol
+++ b/test/ERC721Pricing.t.sol
@@ -59,7 +59,7 @@ contract ERC721PricingTest is DiamondTestUtil, RuleProcessorDiamondTestUtil {
 
     function testERC721PricerVersion() public {
         string memory version = openOcean.version();
-        assertEq(version,"1.0.0");
+        assertEq(version,"1.0.1");
     }
 
     /// Testing setting the price for a single NFT under the right conditions

--- a/to_relative.sh
+++ b/to_relative.sh
@@ -13,7 +13,7 @@ for dir in "${directories[@]}"; do
         if [ -f "$file" ]; then
              echo "${file}"
             # Replace the old string with the new string and overwrite the file
-            sed -i "" 's%openzeppelin-contracts-upgradeable/%@openzeppelin/contracts-upgradeable/%g' "$file"
+            sed -i "" 's%openzeppelin-contracts-upgradeable/contracts/%@openzeppelin/contracts-upgradeable/%g' "$file"
             sed -i "" 's%openzeppelin-contracts%@openzeppelin%g' "$file"
             sed -i "" 's%@openzeppelin-upgradeable/contracts/%@openzeppelin/contracts-upgradeable/%g' "$file"
             # echo "Replaced openzeppelin-contracts"


### PR DESCRIPTION
- Minor fixes in the to_relative.sh script
- to_relative.sh script now runs as part of the installation process for the package to make sure current issue won't happen again.
- Even though the issue would be corrected at installation time in the clients machine, the script was run to fix current issue, so we don't have the wrong import style in Tron.
- The package.json was updated to now point to version 1.0.1 so it is ready to publish.