### PR TITLE
Se 424 restrict super admins from revoking app admins while admin withdrawal rule active

### DIFF
--- a/src/application/AppManager.sol
+++ b/src/application/AppManager.sol
@@ -136,6 +136,7 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents {
     function revokeRole(bytes32 role, address account) public virtual override(AccessControl, IAccessControl) {
         /// enforcing the min-1-admin requirement.
         if(role == SUPER_ADMIN_ROLE) revert BelowMinAdminThreshold();
+        if(role == APP_ADMIN_ROLE) checkForAdminWithdrawal();
         AccessControl.revokeRole(role, account);
     }
     // /// -------------ADMIN---------------

--- a/test/application/ApplicationAppManager.t.sol
+++ b/test/application/ApplicationAppManager.t.sol
@@ -215,9 +215,14 @@ contract ApplicationAppManagerTest is TestCommonFoundry {
         // try to renounce AppAdmin
         vm.expectRevert(0x23a87520);
         applicationAppManager.renounceAppAdministrator();
+        // try revoking from superAdmin
+        vm.stopPrank();
+        vm.startPrank(superAdmin);
+        vm.expectRevert(0x23a87520);
+        applicationAppManager.revokeRole(APP_ADMIN_ROLE, appAdministrator);
+        // try to deactivate the rule
         vm.stopPrank();
         vm.startPrank(ruleAdmin);
-        // try to deactivate the rule
         vm.expectRevert(0x23a87520);
         applicationCoinHandler.activateAdminWithdrawalRule(false);
         // try to set the rule to a different one.

--- a/test/application/ApplicationAppManager.t.sol
+++ b/test/application/ApplicationAppManager.t.sol
@@ -264,6 +264,11 @@ contract ApplicationAppManagerTest is TestCommonFoundry {
         // try to renounce AppAdmin
         vm.expectRevert(0x23a87520);
         applicationAppManager.renounceAppAdministrator();
+        // try revoking from superAdmin
+        vm.stopPrank();
+        vm.startPrank(superAdmin);
+        vm.expectRevert(0x23a87520);
+        applicationAppManager.revokeRole(APP_ADMIN_ROLE, appAdministrator);
         // try to deactivate the rule
         vm.stopPrank();
         vm.startPrank(ruleAdmin);


### PR DESCRIPTION
turned out to be smaller than what I thought.