### PR TITLE
Se 449 create GitHub workflow for necessist run

### DIFF
--- a/.github/workflows/necessist.yml
+++ b/.github/workflows/necessist.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate new Image Tag
         run: |
-          echo "NECESSIST_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:necessist:latest" >> $GITHUB_ENV
+          echo "NECESSIST_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:necessist-${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Build and push docker image
         run: |

--- a/.github/workflows/necessist.yml
+++ b/.github/workflows/necessist.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate new Image Tag
         run: |
-          echo "NECESSIST_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:necessist" >> $GITHUB_ENV
+          echo "NECESSIST_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:necessist:latest" >> $GITHUB_ENV
 
       - name: Build and push docker image
         run: |

--- a/.github/workflows/necessist.yml
+++ b/.github/workflows/necessist.yml
@@ -1,0 +1,64 @@
+name: Run Necessist
+
+on:
+  workflow_dispatch:
+    inputs:
+      TEMP:
+        description: "Placeholder for now"
+        required: false
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: ${{ secrets.K8S_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/universus-tf
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.K8S_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.K8S_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl
+          curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo apt-get update
+          sudo apt-get install -y awscli kubectl
+
+      - name: Configure AWS CLI
+        run: |
+          aws eks update-kubeconfig --name universus --region ${{ env.AWS_REGION }}
+
+      - name: Generate new Image Tag
+        run: |
+          echo "NECESSIST_IMAGE_TAG=${{ ECR_REPOSITORY }}:necessist" >> $GITHUB_ENV
+
+      - name: Build and push docker image
+        run: |
+          docker build -t ${{ env.NECESSIST_IMAGE_TAG }} -f Dockerfile.necessist . --build-arg AWS_ACCESS_KEY_ID=${{ secrets.K8S_AWS_ACCESS_KEY_ID }} --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.K8S_AWS_SECRET_ACCESS_KEY }} --build-arg AWS_REGION=${{ env.AWS_REGION }}
+          docker push ${{ env.NECESSIST_IMAGE_TAG }}
+
+      - name: Update k8s manifest
+        run: |
+          sed -i "s|{{NECESSIST_IMAGE_TAG}}|${{ env.NECESSIST_IMAGE_TAG }}|g" k8s/tron/necessist-job.yaml
+
+      - name: Run the necessist job with k8s
+        run: |
+          kubectl delete job necessist --ignore-not-found=true -n dev
+          sleep 5
+          kubectl apply -f k8s/tron/necessist-job.yaml -n dev

--- a/.github/workflows/necessist.yml
+++ b/.github/workflows/necessist.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Generate new Image Tag
         run: |
-          echo "NECESSIST_IMAGE_TAG=${{ ECR_REPOSITORY }}:necessist" >> $GITHUB_ENV
+          echo "NECESSIST_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:necessist" >> $GITHUB_ENV
 
       - name: Build and push docker image
         run: |

--- a/Dockerfile.anvil
+++ b/Dockerfile.anvil
@@ -13,4 +13,4 @@ ENV CHAIN_ID 31337
 
 RUN pip install -r requirements.txt
 
-ENTRYPOINT anvil --host 0.0.0.0 --chain-id $CHAIN_ID
+ENTRYPOINT anvil --host 0.0.0.0 --code-size-limit 0x60000 --chain-id $CHAIN_ID

--- a/Dockerfile.anvil
+++ b/Dockerfile.anvil
@@ -13,4 +13,4 @@ ENV CHAIN_ID 31337
 
 RUN pip install -r requirements.txt
 
-ENTRYPOINT anvil --host 0.0.0.0 --code-size-limit 0x60000 --chain-id $CHAIN_ID
+ENTRYPOINT anvil --host 0.0.0.0 --chain-id $CHAIN_ID

--- a/Dockerfile.necessist
+++ b/Dockerfile.necessist
@@ -1,0 +1,31 @@
+FROM debian:bookworm
+
+RUN apt update
+RUN apt install -y curl unzip git make procps python3 python3-pip python3.11-venv pkg-config libsqlite3-dev build-essential openssl libssl-dev npm 
+
+WORKDIR /usr/local/src/tron
+
+COPY . .
+
+RUN curl -L https://foundry.paradigm.xyz | bash
+RUN chmod a+x install-forge.sh necessist-run.sh
+RUN ./install-forge.sh
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
+ARG AWS_REGION
+
+ENV AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+ENV AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+ENV AWS_DEFAULT_REGION=${AWS_REGION}
+
+RUN curl https://sh.rustup.rs -sSf > rustup.sh
+RUN chmod a+x rustup.sh
+RUN ./rustup.sh -y
+
+#CMD ["tail", "-f", "/dev/null"]
+CMD ["./necessist-run.sh"]

--- a/Dockerfile.necessist
+++ b/Dockerfile.necessist
@@ -11,7 +11,7 @@ RUN curl -L https://foundry.paradigm.xyz | bash
 RUN chmod a+x install-forge.sh necessist-run.sh
 RUN ./install-forge.sh
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 

--- a/Dockerfile.tron
+++ b/Dockerfile.tron
@@ -10,4 +10,4 @@ COPY . .
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN chmod a+x install-forge.sh
 
-CMD ["./install-forge.sh"]
+CMD ["./install-forge.sh --with-deploy"]

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,15 +5,15 @@ libs = ['lib']
 
 [profile.local]
 eth-rpc-url = 'http://localhost:8545'
-code-size-limit = 0x60000
+code-size-limit = 45000
 
 [profile.docker]
 eth-rpc-url = 'http://anvil:8545'
-code-size-limit = 0x60000
+code-size-limit = 45000
 
 [profile.polygon]
 eth-rpc-url = 'http://172.20.0.2:10002'
-code-size-limit = 0x60000
+code-size-limit = 45000
 
 remappings = ["forge-std/=lib/forge-std/src/",
     "ds-test/=lib/forge-std/lib/ds-test/src/",

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,12 +5,15 @@ libs = ['lib']
 
 [profile.local]
 eth-rpc-url = 'http://localhost:8545'
+code-size-limit = 0x60000
 
 [profile.docker]
 eth-rpc-url = 'http://anvil:8545'
+code-size-limit = 0x60000
 
 [profile.polygon]
 eth-rpc-url = 'http://172.20.0.2:10002'
+code-size-limit = 0x60000
 
 remappings = ["forge-std/=lib/forge-std/src/",
     "ds-test/=lib/forge-std/lib/ds-test/src/",

--- a/install-forge.sh
+++ b/install-forge.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+
+WITH_DEPLOY=$1
 
 source ~/.bashrc
 foundryup
@@ -8,4 +11,6 @@ python3 -m pip install -r requirements.txt
 
 git submodule update --init --recursive   
 
-make build deployAll deployAllApp
+if [ $WITH_DEPLOY = "--with-deploy" ]; then
+	make build deployAll deployAllApp
+fi

--- a/k8s/tron/necessist-job.yaml
+++ b/k8s/tron/necessist-job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: necessist
+  namespace: dev
+spec:
+  template:
+    metadata:
+      name: necessist
+    spec:
+      containers:
+      - name: necessist
+        image: {{NECESSIST_IMAGE_TAG}}
+      restartPolicy: Never

--- a/necessist-run.sh
+++ b/necessist-run.sh
@@ -5,5 +5,5 @@ source ~/.bashrc
 source ~/.cargo/env
 source .venv/bin/activate
 cargo install necessist
-git checkout external
+#git checkout external
 necessist --verbose --framework foundry -- --ffi

--- a/necessist-run.sh
+++ b/necessist-run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+source ~/.bashrc
+source ~/.cargo/env
+source .venv/bin/activate
+cargo install necessist
+git checkout external
+necessist --verbose --framework foundry -- --ffi

--- a/necessist-run.sh
+++ b/necessist-run.sh
@@ -5,5 +5,7 @@ source ~/.bashrc
 source ~/.cargo/env
 source .venv/bin/activate
 cargo install necessist
-#git checkout external
 necessist --verbose --framework foundry -- --ffi
+
+date=$(date +"%Y-%m-%d")
+aws s3 cp necessist.db s3://necessist-database/necessist-${date}.db

--- a/unpack.sh
+++ b/unpack.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-cp -r src/application src/interfaces src/data src/pricing src/token src/economic .
+#cp -r src/client src/common src/example src/protocol .
 
-rm -r src
+#rm -r src


### PR DESCRIPTION
Everything for automating necessist. Includes a dockerfile for the necessist build, github workflow for building and pushing to ECR as well as redeploying the k8s job from the new container, and a k8s manifest file describing the new necessist job. 

Run the workflow from here in github under Actions -> Run Necessist, and when it finally finishes (the GH workflow itself only takes 5 minutes) there will be a new necessist-YY-mm-dd.db file in the "necessist database" bucket of S3 in our AWS account. Voila! 