### PR TITLE
Temporary Github Action to test AWS CLI changes

### DIFF
--- a/.github/workflows/debug-aws-cli.yml
+++ b/.github/workflows/debug-aws-cli.yml
@@ -1,0 +1,59 @@
+# Delete this when fix is merged into deployment-check.yml
+name: Test AWS CLI Actions
+
+on: workflow_dispatch
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: ${{ secrets.K8S_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/universus-tf
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.K8S_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.K8S_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Configure AWS CLI
+        run: |
+          aws eks update-kubeconfig --name universus --region ${{ env.AWS_REGION }}
+
+      # - name: Generate new Image Tag
+      #   run: |
+      #     echo "TRON_TESTING_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:deploy-check-${GITHUB_SHA::7}" >> $GITHUB_ENV
+      #     echo 'ANVIL_IMAGE_TAG=${{ env.ECR_REPOSITORY }}:anvil-deploy-check-${{ github.head_ref }}-${GITHUB_SHA::7}' >> $GITHUB_ENV
+
+      # - name: Build and push docker image
+      #   run: |
+      #     docker build -t ${{ env.ANVIL_IMAGE_TAG }} -f Dockerfile.anvil .
+      #     docker build -t ${{ env.TRON_TESTING_IMAGE_TAG }} -f Dockerfile.deploymentCheck . --build-arg AWS_ACCESS_KEY_ID=${{ secrets.K8S_AWS_ACCESS_KEY_ID }} --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.K8S_AWS_SECRET_ACCESS_KEY }} --build-arg AWS_REGION=${{ env.AWS_REGION }} --build-arg BRANCH_NAME=main
+      #     docker push ${{ env.ANVIL_IMAGE_TAG }}
+      #     docker push ${{ env.TRON_TESTING_IMAGE_TAG }}
+
+      # - name: Update k8s manifest
+      #   run: |
+      #     sed -i "s|{{ANVIL_IMAGE_TAG}}|${{ env.ANVIL_IMAGE_TAG }}|g" k8s/anvil/anvil-deployment-check.yaml
+      #     sed -i "s|{{TRON_TESTING_IMAGE_TAG}}|${{ env.TRON_TESTING_IMAGE_TAG }}|g" k8s/tron/deployment-check-job.yaml
+
+      # - name: Run the necessist job with k8s
+      #   run: |
+      #     kubectl delete job deploy-check --ignore-not-found=true -n dev
+      #     sleep 5
+      #     kubectl set image deploy/anvil-deploy-check anvil-deploy-check=${{ env.ANVIL_IMAGE_TAG }} -n dev
+      #     kubectl rollout restart deploy/anvil-deploy-check -n dev
+      #     kubectl apply -f k8s/anvil/deployment-check-service.yaml -n dev
+      #     kubectl apply -f k8s/tron/deployment-check-job.yaml -n dev
+

--- a/.github/workflows/deployment-check.yml
+++ b/.github/workflows/deployment-check.yml
@@ -29,15 +29,6 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ca-certificates curl
-          curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
-          sudo apt-get update
-          sudo apt-get install -y awscli kubectl
-
       - name: Configure AWS CLI
         run: |
           aws eks update-kubeconfig --name universus --region ${{ env.AWS_REGION }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ broadcast/
 #npm deps
 node_modules/
 
+# Python virtual environment
+.venv/
+
 *.idea
 tron/


### PR DESCRIPTION
- Simply removes the `Install AWS CLI` step, as it likely is installed by the `Configure AWS Credentials` step.
- Creates a new action, which only sets up AWS, but does not deploy, which can be invoked manually.