### PR TITLE
use chain_id from system's env

### DIFF
--- a/script/ParseApplicationDeploy.sh
+++ b/script/ParseApplicationDeploy.sh
@@ -8,7 +8,14 @@ function parseContractAddress() {
 
 ENV_FILE=".env"
 
-CHAIN_ID=31337
+if [[ -n $CHAIN_ID ]]; then
+  CHAIN_ID=${CHAIN_ID}
+elif [[ -n $DB_CHAIN ]]; then
+  CHAIN_ID=${DB_CHAIN}
+else
+  CHAIN_ID=31337
+fi
+
 settingChainID=false
 NUMBER=1
   for var in "$@"

--- a/script/ParseProtocolDeploy.sh
+++ b/script/ParseProtocolDeploy.sh
@@ -2,7 +2,14 @@
 
 ENV_FILE=".env"
 
-CHAIN_ID=31337
+if [[ -n $CHAIN_ID ]]; then
+  CHAIN_ID=${CHAIN_ID}
+elif [[ -n $DB_CHAIN ]]; then
+  CHAIN_ID=${DB_CHAIN}
+else
+  CHAIN_ID=31337
+fi
+
 settingChainID=false
 
   for var in "$@"


### PR DESCRIPTION
This should fix the parser scripts so they work equally well in the deploy check pipeline and the real tron deploy pipeline. 