### PR TITLE
Create CODEOWNERS to tag DevOps team on actions, k8s changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Code Owners Configuration, for Reviewer Tagging
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Tag devops for review in all PRs affecting Github Actions
+/.github/ @thrackle-io/devops
+
+# Tag devops for review in all PRs affecting Kubernetes Resources
+/k8s/ @thrackle-io/devops


### PR DESCRIPTION
This will tag all members of the [Thrackle DevOps Group]() for Review during changes to `/.github/` or `/k8s/`. 

This brings visibility to code changes to:
* GitHub Actions Configurations
* Kubernetes resource Manifests 


Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners 

---

Note, this does not block PRs for approval unless "Require a pull request before merging" and "Require Review from Code Owners" are enabled in a Repository's settings. We could enable this in the future as follows:

<img width="838" alt="image" src="https://github.com/thrackle-io/DOOM/assets/610274/ac2c9084-8fbc-4321-aaf9-5db9d9d55f56">

The `@thrackle-io/devops` group must have explicit write access to the repository.
