### PR TITLE
added tests to attempt to break gas limit on getTotalAccValuation

### DIFF
--- a/.env
+++ b/.env
@@ -89,3 +89,5 @@ REVERT_TO_FACET_ADDRESS=""
 
 ## Deployment Recording of Local Chains (for tests)
 RECORD_DEPLOYMENTS_FOR_ALL_CHAINS="false"
+
+SLAM_TOKEN_LOOPS=20

--- a/test/client/application/ProtocolApplicationHandlerTests.t.sol
+++ b/test/client/application/ProtocolApplicationHandlerTests.t.sol
@@ -33,7 +33,7 @@ contract ProtocolApplicationHandlerTests is TestCommonFoundry {
         uint gasEnd = gasleft();
         // console2.log("gas: ", gasBegin - gasEnd);
         // console2.log("valuation: ", valuation);
-        assertEq(valuation, loops * 100 * 100 * 1e18);
+        assertEq(valuation, loops * 100 * 100 * 1e17);
         assertLt(gasBegin - gasEnd, 15000000); // assert that it is less than the gas limit
     }
 }

--- a/test/client/application/ProtocolApplicationHandlerTests.t.sol
+++ b/test/client/application/ProtocolApplicationHandlerTests.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import "test/util/TestCommonFoundry.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+// tests the shared functionality of the erc20 and erc721 combined together
+
+contract ProtocolApplicationHandlerTests is TestCommonFoundry {
+
+    function setUp() external {
+        vm.warp(Blocktime);
+        setUpProcotolAndCreateERC20AndDiamondHandler();
+    }
+
+    // note: make a test for get acc total valuation 
+    function test_getAccTotalValuation_SlamWithTokensFindGasBreakageValueLimitLow() public {
+        uint loops = vm.envOr("SLAM_TOKEN_LOOPS", uint(20));
+        for (uint i = 0; i < loops; ++i) {
+            switchToAppAdministrator();
+            (ApplicationERC721 TestNFTCoin, ) = deployAndSetupERC721(string.concat("TestNFT", Strings.toString(i)), string.concat("TESTNFT", Strings.toString(i)));
+            switchToAppAdministrator();
+            for (uint j = 0; j < 100; ++j) {
+                ProtocolERC721(address(TestNFTCoin)).safeMint(appAdministrator);
+            }
+            erc721Pricer.setNFTCollectionPrice(address(TestNFTCoin), 10 * ATTO);
+            (ApplicationERC20 TestCoin, ) = deployAndSetupERC20(string.concat("TestERC", Strings.toString(i)), string.concat("TEST", Strings.toString(i)));
+            ProtocolERC20(address(TestCoin)).mint(appAdministrator, 100);
+        }
+
+        uint gasBegin = gasleft();
+        applicationHandler.getAccTotalValuation(appAdministrator, 0);
+        uint gasEnd = gasleft();
+        assertLt(gasBegin - gasEnd, 15000000); // assert that it is less than the gas limit
+    }
+}

--- a/test/client/application/ProtocolApplicationHandlerTests.t.sol
+++ b/test/client/application/ProtocolApplicationHandlerTests.t.sol
@@ -29,8 +29,11 @@ contract ProtocolApplicationHandlerTests is TestCommonFoundry {
         }
 
         uint gasBegin = gasleft();
-        applicationHandler.getAccTotalValuation(appAdministrator, 0);
+        uint valuation = applicationHandler.getAccTotalValuation(appAdministrator, 0);
         uint gasEnd = gasleft();
+        // console2.log("gas: ", gasBegin - gasEnd);
+        // console2.log("valuation: ", valuation);
+        assertEq(valuation, loops * 100 * 100 * 1e18);
         assertLt(gasBegin - gasEnd, 15000000); // assert that it is less than the gas limit
     }
 }

--- a/test/client/token/ERC721/integration/ERC721CommonTests.t.sol
+++ b/test/client/token/ERC721/integration/ERC721CommonTests.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "test/util/TestCommonFoundry.sol";
 import "../../TestTokenCommon.sol";
 import "test/client/token/ERC721/util/ERC721Util.sol";
+import "forge-std/console2.sol";
 
 abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
     IERC721 testCaseNFT;
@@ -1326,6 +1327,139 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         assertFalse(ERC721TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(ActionTypes.BURN));
     }
 
+    function testERC721_ERC721CommonTests_getAccTotalValuation_TestGasLimitBreakageNFTsValueLimitLow() public {
+        // fill an account with NFTs and try to break the gas limit
+        switchToAppAdministrator();
+        _safeMintERC721(20000);
+
+        erc721Pricer.setNFTCollectionPrice(address(testCaseNFT), 1 * ATTO);
+
+        ERC721HandlerMainFacet(address(applicationNFTHandler)).setNFTValuationLimit(20);
+        uint gasBegin = gasleft();
+        uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 20);
+        uint gasEnd = gasleft();
+        assertLt(gasBegin - gasEnd, 42000);
+    }
+
+    function testERC721_ERC721CommonTests_getAccTotalValuation_TestGasLimitBreakageNFTsValueLimitHigh() public {
+        // fill an account with NFTs and try to break the gas limit
+        switchToAppAdministrator();
+        _safeMintERC721(20000);
+
+        erc721Pricer.setNFTCollectionPrice(address(testCaseNFT), 1 * ATTO);
+
+        switchToAppAdministrator();
+        ERC721HandlerMainFacet(address(applicationNFTHandler)).setNFTValuationLimit(20000);
+        uint gasBegin = gasleft();
+        uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 20000);
+        uint gasEnd = gasleft();
+
+        console2.log("valuation: ", totalValuation);
+        assertLt(gasBegin - gasEnd, 42000);
+    }
+
+    function testERC721_ERC721CommonTests_getAccTotalValuation_TestGasLimitBreakageMultipleNFTsValueLimitHigh() public {
+        // fill an account with NFTs and try to break the gas limit
+        switchToAppAdministrator();
+
+        // deploy its always sunny nfts
+        (ApplicationERC721 FrankCoin, ) = deployAndSetupERC721("Frankcoin", "FRANK");
+        (ApplicationERC721 DennisCoin, ) = deployAndSetupERC721("Denniscoin", "DENNIS");
+        (ApplicationERC721 DeeCoin, ) = deployAndSetupERC721("Deecoin", "DEE");
+        (ApplicationERC721 MacCoin, ) = deployAndSetupERC721("Maccoin", "MAC");
+        (ApplicationERC721 CharlieCoin, ) = deployAndSetupERC721("Charliecoin", "CHARLIE");
+        (ApplicationERC721 WaitressCoin, ) = deployAndSetupERC721("Waitresscoin", "WAITRESS");
+        (ApplicationERC721 CricketCoin, ) = deployAndSetupERC721("Cricketcoin", "CRICKET");
+        
+        
+        // mint a crapload of nfts
+        switchToAppAdministrator();
+        _safeMintERC721(10000);
+        _safeMintERC721TokenDefined(address(FrankCoin), 1000);
+        _safeMintERC721TokenDefined(address(DennisCoin), 500);
+        _safeMintERC721TokenDefined(address(DeeCoin), 300);
+        _safeMintERC721TokenDefined(address(MacCoin), 200);
+        _safeMintERC721TokenDefined(address(CharlieCoin), 140);
+        _safeMintERC721TokenDefined(address(WaitressCoin), 140);
+        _safeMintERC721TokenDefined(address(CricketCoin), 140);
+
+
+        // set pricing
+        switchToAppAdministrator();
+        erc721Pricer.setNFTCollectionPrice(address(testCaseNFT), 1 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(FrankCoin), 10000 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(DennisCoin), 69 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(DeeCoin), 2 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(MacCoin), 7 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(CharlieCoin), 42 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(CricketCoin), 666 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(WaitressCoin), 200 * ATTO);
+        
+        /// set the nftHandler nftValuationLimit variable
+        switchToAppAdministrator();
+        ERC721HandlerMainFacet(address(applicationNFTHandler)).setNFTValuationLimit(20000);
+        
+        // track the gas
+        uint gasBegin = gasleft();
+        uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 10000);
+        uint gasEnd = gasleft();
+
+        assertLt(gasBegin - gasEnd, 30000000); // assert that this is less than the block gas limit on polygon pos
+        assertEq(totalValuation, 10173620000000000000000000); // get a free valuation assertion while we're here
+    }
+
+    function testERC721_ERC721CommonTests_getAccTotalValuation_TestGasLimitBreakageMultipleNFTsValueLimitLow() public {
+        // fill an account with NFTs and try to break the gas limit
+        switchToAppAdministrator();
+
+        // deploy its always sunny nfts
+        (ApplicationERC721 FrankCoin, ) = deployAndSetupERC721("Frankcoin", "FRANK");
+        (ApplicationERC721 DennisCoin, ) = deployAndSetupERC721("Denniscoin", "DENNIS");
+        (ApplicationERC721 DeeCoin, ) = deployAndSetupERC721("Deecoin", "DEE");
+        (ApplicationERC721 MacCoin, ) = deployAndSetupERC721("Maccoin", "MAC");
+        (ApplicationERC721 CharlieCoin, ) = deployAndSetupERC721("Charliecoin", "CHARLIE");
+        (ApplicationERC721 WaitressCoin, ) = deployAndSetupERC721("Waitresscoin", "WAITRESS");
+        (ApplicationERC721 CricketCoin, ) = deployAndSetupERC721("Cricketcoin", "CRICKET");
+        
+        
+        // mint a crapload of nfts
+        switchToAppAdministrator();
+        _safeMintERC721(10000);
+        _safeMintERC721TokenDefined(address(FrankCoin), 1000);
+        _safeMintERC721TokenDefined(address(DennisCoin), 500);
+        _safeMintERC721TokenDefined(address(DeeCoin), 300);
+        _safeMintERC721TokenDefined(address(MacCoin), 200);
+        _safeMintERC721TokenDefined(address(CharlieCoin), 140);
+        _safeMintERC721TokenDefined(address(WaitressCoin), 140);
+        _safeMintERC721TokenDefined(address(CricketCoin), 140);
+
+
+        // set pricing
+        switchToAppAdministrator();
+        erc721Pricer.setNFTCollectionPrice(address(testCaseNFT), 1 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(FrankCoin), 10000 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(DennisCoin), 69 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(DeeCoin), 2 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(MacCoin), 7 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(CharlieCoin), 42 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(CricketCoin), 666 * ATTO);
+        erc721Pricer.setNFTCollectionPrice(address(WaitressCoin), 200 * ATTO);
+        
+        /// set the nftHandler nftValuationLimit variable
+        switchToAppAdministrator();
+        ERC721HandlerMainFacet(address(applicationNFTHandler)).setNFTValuationLimit(10);
+        
+        // track the gas
+        uint gasBegin = gasleft();
+        uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 10);
+        uint gasEnd = gasleft();
+        
+        console2.log("Gas: ", gasBegin - gasEnd);
+
+        assertLt(gasBegin - gasEnd, 70000); // assert that this is less than 70k. This gives us a baseline to understand what our lower bound should be.
+        assertEq(totalValuation, 10173620000000000000000000); // get a free valuation assertion while we're here
+    }
+
     /// INTERNAL HELPER FUNCTIONS
     function _approveTokens(DummyNFTAMM _amm, uint256 amountERC20, bool _isApprovalERC721) internal {
         applicationCoin.approve(address(_amm), amountERC20);
@@ -1335,6 +1469,13 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
     function _safeMintERC721(uint256 amount) internal {
         for (uint256 i; i < amount; i++) {
             ProtocolERC721(address(testCaseNFT)).safeMint(appAdministrator);
+        }
+    }
+
+    function _safeMintERC721TokenDefined(address token, uint256 amount) internal endWithStopPrank {
+        switchToAppAdministrator();
+        for (uint256 i = 0; i < amount; i++) {
+            ProtocolERC721(address(token)).safeMint(appAdministrator);
         }
     }
 

--- a/test/client/token/ERC721/integration/ERC721CommonTests.t.sol
+++ b/test/client/token/ERC721/integration/ERC721CommonTests.t.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.24;
 import "test/util/TestCommonFoundry.sol";
 import "../../TestTokenCommon.sol";
 import "test/client/token/ERC721/util/ERC721Util.sol";
-import "forge-std/console2.sol";
 
 abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
     IERC721 testCaseNFT;
@@ -1336,7 +1335,7 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
 
         ERC721HandlerMainFacet(address(applicationNFTHandler)).setNFTValuationLimit(20);
         uint gasBegin = gasleft();
-        uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 20);
+        applicationHandler.getAccTotalValuation(appAdministrator, 20);
         uint gasEnd = gasleft();
         assertLt(gasBegin - gasEnd, 42000);
     }
@@ -1351,10 +1350,9 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         switchToAppAdministrator();
         ERC721HandlerMainFacet(address(applicationNFTHandler)).setNFTValuationLimit(20000);
         uint gasBegin = gasleft();
-        uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 20000);
+        applicationHandler.getAccTotalValuation(appAdministrator, 20000);
         uint gasEnd = gasleft();
 
-        console2.log("valuation: ", totalValuation);
         assertLt(gasBegin - gasEnd, 42000);
     }
 
@@ -1454,7 +1452,7 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         uint totalValuation = applicationHandler.getAccTotalValuation(appAdministrator, 10);
         uint gasEnd = gasleft();
         
-        console2.log("Gas: ", gasBegin - gasEnd);
+        //console2.log("Gas: ", gasBegin - gasEnd);
 
         assertLt(gasBegin - gasEnd, 70000); // assert that this is less than 70k. This gives us a baseline to understand what our lower bound should be.
         assertEq(totalValuation, 10173620000000000000000000); // get a free valuation assertion while we're here


### PR DESCRIPTION
Findings: 

1. Nft limit valuation will do the trick, it will take unbounded gas usage that can reach 100 million units of gas used and convert it downwards to levels of about 69k units of gas used. Going forward, this should be assumed to be 0 when interacting with the protocol unless given a significant suggestion as to why not (perhaps around discussions of potential arbitrage from values not being counted properly from NFT standpoint). 

2. A large set of NFTs and ERC20s (which we've set to about 20 for a default but can be configurable beyond here), will yield  a gas usage of 278047. Thats 278k to evaluate 20 NFTs and 20 ERC20s for their price and how it tracks when used within the EVM. 

3. Created a new file to handle application manager interactions that use both tokens. 
