### PR TITLE
add invariant document clarification

### DIFF
--- a/docs/userGuides/development/invariants/Pricing-Invariants.md
+++ b/docs/userGuides/development/invariants/Pricing-Invariants.md
@@ -14,6 +14,7 @@
 
 
 ## ERC721-Pricing Invariants
+##### Note: Not implemented yet
 
 - Version will never be blank
 - Version will never change.

--- a/docs/userGuides/development/invariants/client/application/AppManager-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/AppManager-Invariants.md
@@ -1,7 +1,6 @@
 # AppManager Invariants
 
-## [Role Management Invariants](../../../test/client/application/invariant/ApplicationAppManagerRoles.t.i.sol)
-
+## [Role Management Invariants](../../../../../../test/client/application/invariant/ApplicationAppManagerRoles.t.i.sol)
 - There will always be a SuperAdmin
 - When grantRole is called directly on the AppManager contract the transaction will be reverted.
 - When renounceRole is called by the Super Admin the transaction will be reverted.
@@ -27,33 +26,33 @@
 - When renounceAccessLevelAdmin is called the AccessLevelAdmin event will be emitted.
   
 
-## [Access Level Invariants](../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
+## [Access Level Invariants](../../../../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
 - If addAccessLevel is called by an account that is not an Access Level Admin the transaction will be reverted.
 - If addAccessLevelToMultipleAccounts is called by an account that is not an Access Level Admin the transaction will be reverted.
 - If addMultipleAccessLevels is called by an account that is not an Access Level Admin the transaction will be reverted. 
 - If removeAccessLevel is called by an account that is not an Access Level Admin the transaction will be reverted.
 
-## [Risk Score Invariants](../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
+## [Risk Score Invariants](../../../../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
 - If addRiskScore is called by an account that is not a Risk Admin the transaction will be reverted.
 - If addRiskScoreToMultipleAccounts is called by an account that is not a Risk Admin the transaction will be reverted.
 - If addMultipleRiskScores is called by an account that is not a Risk Admin the transaction will be reverted. 
 - If removeRiskScore is called by an account that is not a Risk Admin the transaction will be reverted.
 
 
-## [Pause Rule Invariants](../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
+## [Pause Rule Invariants](../../../../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
 - If addPauseRule is called by an account that is not a Rule Admin the transaction will be reverted.
 - If removePauseRule is called by an account that is not a Rule Admin the transaction will be reverted.
 - If activatePauseRuleCheck is called by an account that is not a Rule Admin the transaction will be reverted.
 
 
-## [Tags Invariants](../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
+## [Tags Invariants](../../../../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
 - If addTag is called by an account that is not an App Admin the transaction will be reverted.
 - If addTagToMultipleAccounts is called by an account that is not an App Admin the transaction will be reverted.
 - If addMultipleTagToMultipleAccounts is called by an account that is not an App Admin the transaction will be reverted.
 - If removeTag is called by an account that is not an App Admin the transaction will be reverted.
 
 
-## [Providers](../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
+## [Providers](../../../../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)
 - If proposeRiskScoresProvider is called with an address of 0 the transaction will be reverted.
 - If proposeRiskScoresProvider is called by an account that is not an App Admin the transaction will be reverted.
 - If proposeTagsProvider is called with an address of 0 the transaction will be reverted.
@@ -65,7 +64,7 @@
 - If proposeAccessLevelsProvider is called with an address of 0 the transaction will be reverted.
 - If proposeAccessLevelsProvider is called by an account that is not an App Admin the transaction will be reverted.
 
-## [Registration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [Registration](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If isRegisteredHandler returns false for an address, calling checkApplicationRules from the address will result in the transaction being reverted.
 - If registerToken is called with an address of 0 the transaction will be reverted.
 - If registerToken is called by an account that is not an App Admin the transaction will be reverted. 
@@ -74,20 +73,20 @@
 - If deregisterToken is not reverted the RemoveFromRegistry event will be emitted.
 - If registerAMM is called with an address of 0 the transaction will be reverted. 
 
-## [AMM Registration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [AMM Registration](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If registerAMM is called by an account that is not an App Admin the transaction will be reverted. 
 - If registerAMM is not reverted the AMMRegistered event will be emitted.
 - If deregisterAMM is called by an account that is not an App Admin the transaction will be reverted.
 - If deregisterAMM is called with the address of a token that is not registered, the transaction will be reverted. 
 - If registerTreasury is called with an address of 0 the transaction will be reverted.
 
-## [Treasury Registration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [Treasury Registration](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If registerTreasury is called by an account that is not an App Admin the transaction will be reverted.
 - If registerTreasury is not reverted the TreasuryRegistered event will be emitted.
 - If deregisterTreasury is called by an account that is not an App Admin the transaction will be reverted. 
 - If deregisterTreasury is called with an address that is not registered, the transaction will be reverted.
 
-## [Trading Rule Allow List](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [Trading Rule Allow List](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If approveAddressToTradingRuleAllowlist is called by an account that is not an App Admin the transaction will be reverted.
 - If an address that has not been previously added is passed in along with a false for isApproved the transaction will be reverted.
 - If an address that is already approved is passed in along with a true for isApproved the transaction will be reverted. 
@@ -99,18 +98,18 @@
 - If proposeDataContractMigration is called by an account that is not an App Admin the transaction will be reverted. 
 - If proposeDataContractMigation is not reverted the AppManagerDataUpgradeProposed event is emitted.
 
-## [New Data Provider](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [New Data Provider](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - When confirmNewDataProvider is called with a provider type of TAG and is not reverted, the TagProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of RISK_SCORE and is not reverted, the RiskProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of ACCESS_LEVEL and is not reverted, the AccessLevelProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of ACCOUNT and is not reverted, the AccountProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of PAUSE_RULE and is not reverted, the PauseRuleProviderSet event will be emitted.
 
-## [Data Migration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [Data Migration](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If confirmDataContractMigration is called by an account that is not an App Admin the transaction will be reverted.
 - If confirmDataContractMigration is not reverted the DataContractsMigrated event is emitted.
 
-## [App Manager Upgrade](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
+## [App Manager Upgrade](../../../../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If confirmAppManager is called by an account that is not an App Admin the transaction will be reverted. 
 
 

--- a/docs/userGuides/development/invariants/client/application/AppManager-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/AppManager-Invariants.md
@@ -12,7 +12,7 @@
 - When addRuleAdministrator is called by an account other other than an App Admin the transaction will be reverted.
 - When addRuleAdministrator is called with an address of 0 the transaction will be reverted.
 - If addRuleAdministrator is not reverted the RuleAdmin event will be emitted.
-- When renounceRuleAdministrator is called the RuleAdmin event will be emitted.
+- When renounceRuleAdministrator is called the RuleAdministrator event will be emitted.
 - When addRiskAdmin is called by an account other than an App Admin the transaction will be reverted.
 - When addRiskAdmin is called with an address of 0 the transaction will be reverted.
 - If addRiskAdmin is not reverted the RiskAdmin event will be emitted.
@@ -74,15 +74,20 @@
 - If deregisterToken is not reverted the RemoveFromRegistry event will be emitted.
 - If registerAMM is called with an address of 0 the transaction will be reverted. 
 
+## [AMM Registration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If registerAMM is called by an account that is not an App Admin the transaction will be reverted. 
 - If registerAMM is not reverted the AMMRegistered event will be emitted.
 - If deregisterAMM is called by an account that is not an App Admin the transaction will be reverted.
 - If deregisterAMM is called with the address of a token that is not registered, the transaction will be reverted. 
 - If registerTreasury is called with an address of 0 the transaction will be reverted.
+
+## [Treasury Registration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If registerTreasury is called by an account that is not an App Admin the transaction will be reverted.
 - If registerTreasury is not reverted the TreasuryRegistered event will be emitted.
 - If deregisterTreasury is called by an account that is not an App Admin the transaction will be reverted. 
 - If deregisterTreasury is called with an address that is not registered, the transaction will be reverted.
+
+## [Trading Rule Allow List](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If approveAddressToTradingRuleAllowlist is called by an account that is not an App Admin the transaction will be reverted.
 - If an address that has not been previously added is passed in along with a false for isApproved the transaction will be reverted.
 - If an address that is already approved is passed in along with a true for isApproved the transaction will be reverted. 
@@ -94,13 +99,18 @@
 - If proposeDataContractMigration is called by an account that is not an App Admin the transaction will be reverted. 
 - If proposeDataContractMigation is not reverted the AppManagerDataUpgradeProposed event is emitted.
 
+## [New Data Provider](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - When confirmNewDataProvider is called with a provider type of TAG and is not reverted, the TagProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of RISK_SCORE and is not reverted, the RiskProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of ACCESS_LEVEL and is not reverted, the AccessLevelProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of ACCOUNT and is not reverted, the AccountProviderSet event will be emitted.
 - When confirmNewDataProvider is called with a provider type of PAUSE_RULE and is not reverted, the PauseRuleProviderSet event will be emitted.
+
+## [Data Migration](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If confirmDataContractMigration is called by an account that is not an App Admin the transaction will be reverted.
 - If confirmDataContractMigration is not reverted the DataContractsMigrated event is emitted.
+
+## [App Manager Upgrade](../../../test/client/application/invariant/ApplicationAppManager.t.i.sol)
 - If confirmAppManager is called by an account that is not an App Admin the transaction will be reverted. 
 
 

--- a/docs/userGuides/development/invariants/client/application/ProtocolApplicationHandler-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/ProtocolApplicationHandler-Invariants.md
@@ -1,5 +1,7 @@
 # ApplicationProtocolHandler Invariants
 
+### Note: Not implemented yet
+
 - Upon creation of the contract the App Manager address passed in to the constructor will be the contracts owner.
 - If checkApplicationRules is called by an account that is not the registered AppManager the transaction will be reverted.
 

--- a/docs/userGuides/development/invariants/client/application/data/AccessLevels-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/AccessLevels-Invariants.md
@@ -1,14 +1,11 @@
 # AccessLevels Invariants
 
+##### Note: Not implemented, will be implemented later
+
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
-- When addLevel is called by an address that is not the registered App Manager the transaction will be reverted.
 - When addLevel is called with a level value greater than 4 the transaction will be reverted.
 - When addLevel is called with an address of 0 the transaction will be reverted.
 - If addLevel is not reverted the AccessLevelAdded event will be emitted.
-
-- When addAccessLevelToMultipleAccounts is called by an address that is not the registered App Manager the transaction will be reverted.
 - When addAccessLevelToMultipleAccounts is called with a level value greater than 4 the transaction will be reverted.
 - If addAccessLevelToMultipleAccounts is not reverted the AccessLevelAdded event will be emitted for each address in the array.
-
-- When removeAccessLevel is called by an address that is not the registered App Manager the transaction will be reverted.
 - If removeAccessLevel is not reverted the AccessLevelRemoved event will be emitted for each address in the array.

--- a/docs/userGuides/development/invariants/client/application/data/Accounts-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/Accounts-Invariants.md
@@ -1,5 +1,7 @@
 # Accounts Invariants
 
+#### Note: Not implemented, todo later
+
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
 - When addAccount is called by an address that is not the registered App Manager the transaction will be reverted.
 - If addAccount is called with an address of 0 the transaction will be reverted.

--- a/docs/userGuides/development/invariants/client/application/data/Accounts-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/Accounts-Invariants.md
@@ -2,6 +2,8 @@
 
 #### Note: Not implemented, todo later
 
+#### Note: Delete me maybe? 
+
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
 - When addAccount is called by an address that is not the registered App Manager the transaction will be reverted.
 - If addAccount is called with an address of 0 the transaction will be reverted.

--- a/docs/userGuides/development/invariants/client/application/data/DataModule-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/DataModule-Invariants.md
@@ -1,5 +1,7 @@
 # Data Module Invariants
 
+##### Note: Todo, not implemented
+
 - The Data Module contract can not be instantiated.
 - If proposeOwner is called by an address that is not either the current owner or an App Admin the transaction will be reverted.
 - If proposeOwner is called with an address of 0 the transaction will be reverted. 

--- a/docs/userGuides/development/invariants/client/application/data/PauseRules-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/PauseRules-Invariants.md
@@ -1,11 +1,9 @@
 # Pause Rules Invariants
 
+##### Note: Not implemented, todo
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
-- If addPauseRule is called by an address that is not the registered App Manager the transaction will be reverted.
 - If addPauseRule is called with a pauseStop that is less than pauseStart the transaction will be reverted. 
 - If addPauseRule is called with a pauseStart is less than the current block timestamp the transaction will be reverted.
 - If addPauseRule is not reverted the PauseRuleEvent event will be emitted. 
-
-- If removePauseRule is called by an address that is not the registered App Manager the transaction will be reverted. 
 - If getPauseRules is called by an address that is not the registered App Manager the transaction will be reverted. 
 - If isPauseRulesEmpty is called by an address that is not the registered App Manager the transaction will be reverted.  

--- a/docs/userGuides/development/invariants/client/application/data/PauseRules-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/PauseRules-Invariants.md
@@ -1,6 +1,6 @@
 # Pause Rules Invariants
 
-##### Note: Not implemented, todo
+###### Note: Invariants not implemented yet but properly fuzz tested
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
 - If addPauseRule is called with a pauseStop that is less than pauseStart the transaction will be reverted. 
 - If addPauseRule is called with a pauseStart is less than the current block timestamp the transaction will be reverted.

--- a/docs/userGuides/development/invariants/client/application/data/RiskScores-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/RiskScores-Invariants.md
@@ -1,12 +1,13 @@
 # Risk Scores Invariants
 
+##### Note: Not implemented todo
+
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
 - If addScore is called by an address that is not the registered App Manager the transaction will be reverted. 
 - If addScore is called with a value greater than 100 the transaction will be reverted.
 - If addScore is called with an address of 0 the transaction will be reverted. 
 - If addScore is not reverted the RiskScoreAdded event will be emitted. 
 
-- If addRiskScoreToMultipleAccounts is called by an address that is not the registered App Manager the transaction will be reverted.
 - If addRiskScoreToMultipleAccounts is called with a value greater than 100 the transaction will be reverted. 
 - If addRiskScoreToMultipleAccounts is not reverted the RiskScoreAdded event will be emitted for each address in the array.
 

--- a/docs/userGuides/development/invariants/client/application/data/Tags-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/Tags-Invariants.md
@@ -1,14 +1,13 @@
 # Tags Invariants
 
+###### Note: Not implemented, todo
+
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
-- If addTag is called by an address that is not the registered App Manager the transaction will be reverted.
 - If addTag is called with an empty string for the tag the transaction will be reverted.
 - If addTag is called with an address of 0 the transaction will be reverted.
 - If addTag is not reverted the Tag event will be emitted. 
 
-- If addTagToMultipleAccounts is called by an address that is not the registered App Manager the transaction will be reverted. 
 - If addTagToMultipleAccounts is called with an empty string for the tag the transaction will be reverted.
 - If addTagToMultipleAccounts is not reverted the Tag event will be emitted for each address in the array.
 
-- If removeTag is called by an address that is not the registered App Manager the transaction will be reverted.
 - If removeTag is not reverted the Tag event will be emitted.

--- a/docs/userGuides/development/invariants/client/application/data/Tags-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/data/Tags-Invariants.md
@@ -1,6 +1,6 @@
 # Tags Invariants
 
-###### Note: Not implemented, todo
+###### Note: Invariants not implemented yet but properly fuzz tested
 
 - Upon creation ownership of the contract will be transfered to the App Manager address passed in to the constructor.
 - If addTag is called with an empty string for the tag the transaction will be reverted.

--- a/docs/userGuides/development/invariants/client/token/ERC20/ProtocolERC20-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/ERC20/ProtocolERC20-invariants.md
@@ -18,7 +18,7 @@
 - Allowances should be updated correctly when approve is called twice.
 - TransferFrom should decrease allowance
 
-## [Burnable ERC20 Invariants](../../../../../../../test/client/token/ERC20/invariant/ApplicationERCMintBurn.t.i.sol)
+## [Burnable ERC20 Invariants](../../../../../../../test/client/token/ERC20/invariant/ApplicationERC20MintBurn.t.i.sol)
 - Burn should update user balance and total supply
 - Burn should update user balance and total supply when burnFrom is called twice
 - burnFrom should update allowance

--- a/docs/userGuides/development/invariants/client/token/ERC20/ProtocolERC20-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/ERC20/ProtocolERC20-invariants.md
@@ -1,7 +1,36 @@
 # ProtocolERC20 Invariants
 
-## Protocol Related Invariants
+## [Base ERC20 Invariants](../../../../../../../test/client/token/ERC20/invariant/ApplicationERC20Basic.t.i.sol)
+- User balance must not exceed total supply
+- Sum of users balance must not exceed total supply
+- Address zero should have zero balance
+- Transfers to zero address should not be allowed.
+- transferFroms to zero address should not be allowed.
+- Self transfers should not break accounting.
+- Self transferFroms should not break accounting.
+- Transfers for more than available balance should not be allowed
+- TransferFroms for more than available balance should not be allowed
+- Zero amount transfers should not break accounting
+- Zero amount transferFroms should not break accounting
+- Transfers should update accounting correctly
+- TransferFroms should update accounting correctly
+- Approve should set correct allowances
+- Allowances should be updated correctly when approve is called twice.
+- TransferFrom should decrease allowance
 
+## [Burnable ERC20 Invariants](../../../../../../../test/client/token/ERC20/invariant/ApplicationERCMintBurn.t.i.sol)
+- Burn should update user balance and total supply
+- Burn should update user balance and total supply when burnFrom is called twice
+- burnFrom should update allowance
+
+## [Pausable ERC20 Invariants](../../../../../../../test/client/token/ERC20/invariant/ApplicationERC20Pause.t.i.sol)
+- Transfers should not be possible during paused state
+- TransferFroms should not be possible during paused state
+
+# Unimplemented
+
+## Protocol Related Invariants
+##### note: Not implemented fully
 - Version will never be blank
 - Version will never change.
 - Any user can get the contract's version
@@ -22,35 +51,12 @@
 - If a cumulative positive fees exist, the treasury address balance will increase with a transfer
 - If a cumulative negative fees exist, the treasury address balance will remain the same with a transfer
 
-## Base ERC20 Invariants
-- Total supply should be constant for non-mintable and non-burnable tokens.
-- No user balance should be greater than the token's total supply.
-- The sum of all user balances should equal the token's total supply.
-- Token balance for address zero should be zero.
-- transfers to zero address should not be allowed.
-- transferFroms to zero address should not be allowed.
-- Self transfers should not break accounting.
-- Self transferFroms should not break accounting.
-- transfers for more than account balance should not be allowed.
-- transferFroms for more than account balance should not be allowed.
-- transfers for zero amount should not break accounting.
-- transferFroms for zero amount should not break accounting.
-- Valid transfers should update accounting correctly.
-- Valid transferFroms should update accounting correctly.
-- Allowances should be set correctly when approve is called.
-- Allowances should be updated correctly when approve is called twice.
-- After transferFrom, allowances should be updated correctly.
-
-## Burnable ERC20 Invariants
-- User balance and total supply should be updated correctly when burn is called.
-- User balance and total supply should be updated correctly when burnFrom is called.
-- Allowances should be updated correctly when burnFrom is called.
 
 ## Mintable ERC20 Invariants
 - User balance and total supply should be updated correctly after minting.
 
-## ProtocolTokenCommon Invariants
 
+## ProtocolTokenCommon Invariants
 - Only an App Admin can propose a new AppManager
 - Proposed AppManagerAddress can not be set to zero address
 - Any type of address may confirm the proposed AppManager as long as it is the proposed AppManager.

--- a/docs/userGuides/development/invariants/client/token/ERC721/ProtocolERC721-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/ERC721/ProtocolERC721-invariants.md
@@ -22,7 +22,7 @@
 - getApproved() should revert if the token is burned
 - ownerOf() should revert if the token has been burned.
 
-## [Mintable ERC721 Invariants]((../../../../../../../test/client/token/ERC721/invariant/ApplicationERC721MintBurn.t.i.sol))
+## [Mintable ERC721 Invariants](../../../../../../../test/client/token/ERC721/invariant/ApplicationERC721MintBurn.t.i.sol)
 - Mint increases the total supply
 - Mint creates a fresh applicationNFT
 

--- a/docs/userGuides/development/invariants/client/token/ERC721/ProtocolERC721-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/ERC721/ProtocolERC721-invariants.md
@@ -1,5 +1,34 @@
 # ProtocolERC721 Invariants
 
+
+
+## [Base ERC721 Invariants](../../../../../../../test/client/token/ERC721/invariant/ApplicationERC721Base.t.i.sol)
+- Calling balanceOf for the zero address should revert.
+- Calling ownerOf for an invalid token should revert.
+- approve() should revert on invalid token.
+- transferFrom() should revert if caller is not approved.
+- transferFrom() should reset approvals.
+- transferFrom() should update the token owner.
+- transferFrom() should revert if from is the zero address.
+- transferFrom() should revert if to is the zero address.
+- transferFrom() to self should not break accounting.
+- transferFrom() to self should reset approvals.
+  
+
+## [Burnable ERC721 Invariants](../../../../../../../test/client/token/ERC721/invariant/ApplicationERC721MintBurn.t.i.sol)
+- The burn function should destroy tokens and reduce the total supply
+- A burned token should not be transferrable
+- approve() should revert if the token is burned
+- getApproved() should revert if the token is burned
+- ownerOf() should revert if the token has been burned.
+
+## [Mintable ERC721 Invariants]((../../../../../../../test/client/token/ERC721/invariant/ApplicationERC721MintBurn.t.i.sol))
+- Mint increases the total supply
+- Mint creates a fresh applicationNFT
+
+
+# Not Implemented
+
 ## Protocol Related Invariants
 
 - Version will never be blank
@@ -18,30 +47,14 @@
 - When paused, transferFrom reverts with "Pausable: paused"
 - When paused, connectHandlerToToken still works
 
-## Base ERC721 Invariants
-- Calling balanceOf for the zero address should revert.
-- Calling ownerOf for an invalid token should revert.
-- approve() should revert on invalid token.
-- transferFrom() should revert if caller is not operator.
-- transferFrom() should reset approvals.
-- transferFrom() should update the token owner.
-- transferFrom() should revert if from is the zero address.
-- transferFrom() should revert if to is the zero address.
-- transferFrom() to self should not break accounting.
-- transferFrom() to self should reset approvals.
+## Base
 - safeTransferFrom() should revert if receiver is a contract that does not implement onERC721Received()
-  
 
-## Burnable ERC721 Invariants
-- User balance and total supply should be updated correctly when burn is called.
-- A token that has been burned cannot be transferred.
-- A token that has been burned cannot be transferred.
+## Minting
+- Minting tokens should update user's balance
+
+## Burning
 - A burned token should have its approvals reset.
-- getApproved() should revert if the token is burned.
-- ownerOf() should revert if the token has been burned.
-
-## Mintable ERC721 Invariants
-- User balance and total supply should be updated correctly after minting.
 
 ## ProtocolTokenCommon Invariants
 

--- a/docs/userGuides/development/invariants/client/token/ERC721/upgradeable/ProtocolERC721U-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/ERC721/upgradeable/ProtocolERC721U-invariants.md
@@ -1,5 +1,7 @@
 # ProtocolERC721U Invariants
 
+##### Note: See ERC721-Invariants page one level up which has most up to date information on what has been invarianted for ERC721, nothing has been implemented for the upgradeable ERC721s. 
+
 ## Protocol Related Invariants
 
 - Version will never be blank

--- a/docs/userGuides/development/invariants/client/token/handler/Fees-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/handler/Fees-invariants.md
@@ -1,5 +1,5 @@
 # Fees Invariants
-
+###### Note: Not implemented, todo
 ## FeesFacet Invariants
 
 - Only a ruleAdmin can activate a set fee activation

--- a/docs/userGuides/development/invariants/client/token/handler/ProtocolERC20Handler-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/handler/ProtocolERC20Handler-invariants.md
@@ -1,5 +1,6 @@
 # ProtocolERC20Handler Invariants
 
+##### Note: not implemented, todo
 This document covers all the facets for the ERC20 handler, its rules, and the inherited contracts it uses.
 
 ## ERC20HandlerMainFacet Invariants

--- a/docs/userGuides/development/invariants/client/token/handler/ProtocolERC721Handler-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/handler/ProtocolERC721Handler-invariants.md
@@ -1,5 +1,6 @@
 # ProtocolERC721Handler Invariants
 
+##### Note: not implemented, todo
 This document covers all the facets for the ERC20 handler, its rules, and the inherited contracts it uses.
 
 ## ERC721HandlerMainFacet Invariants

--- a/docs/userGuides/development/invariants/client/token/handler/common/HandlerUtils-invariants.md
+++ b/docs/userGuides/development/invariants/client/token/handler/common/HandlerUtils-invariants.md
@@ -1,9 +1,10 @@
 # Handler Utils Invariants
 
 ## HandlerUtils Invariants
-
+##### Note: HandlerUtils Invariants are not implemented yet
 - When mint, determineTransferAction always returns ActionTypes.MINT 
 - When burn, determineTransferAction always returns ActionTypes.BURN 
 - When sell, determineTransferAction always returns ActionTypes.SELL 
 - When buy, determineTransferAction always returns ActionTypes.BUY 
 - When p2ptransfer, determineTransferAction always returns ActionTypes.P2P_TRANSFER 
+

--- a/docs/userGuides/development/invariants/protocol/Protocol-invariants.md
+++ b/docs/userGuides/development/invariants/protocol/Protocol-invariants.md
@@ -66,7 +66,7 @@ All invariants have links to their invariant test files unless specified otherwi
 
 - When this rule is applied, an NFT can never be transferred before the hold-time period has passed counting from the last trade date.
 
-## Rule Invariants - Without Stat Variables
+## Rule Invariants - Without State Variables
 
 ### Balance By Access Level *
 

--- a/docs/userGuides/development/invariants/protocol/Protocol-invariants.md
+++ b/docs/userGuides/development/invariants/protocol/Protocol-invariants.md
@@ -20,15 +20,15 @@ All invariants have links to their invariant test files unless specified otherwi
 
 ### [All Rules - Processing and Application](/test/client/token/invariant/)
 
-- Rules can be shared by multiple applications and/or assets.
 - Deactivating a rule in one token, AMM or Application does not affect its application in others.
-- Rules at the application level apply to all registered tokens.
+- Rules can be shared by multiple applications and/or assets. # note not implemented
+- Rules at the application level apply to all registered tokens. # note not implemented
   
 ## [Rule Invariants - With State Variables](/test/client/token/invariant/)
 
 ### [Account Max Value Out By Access Level](/test/client/token/invariant/accountMaxValueOutByAccessLevel/RuleProcessingAccountMaxValueOutByAccessLevelMulti.t.i.sol)
 
-- When this rule is applied, An account's cumulative total of funds withdrawn from the protocol in USD terms must not exceed the maximum for that account's access level defined in the Account-Max-Value-Out-By-Access-Level rule applied for the application counting from the activation of the rule. This is a lifetime cumulative total which can't be ever reset.
+- When this rule is applied, An account's cumulative total of funds withdrawn from the protocol in USD terms must not exceed the maximum for that account's access level defined in the Account-Max-Value-Out-By-Access-Level rule applied for the application counting from the activation of the rule. 
 
 ### [Account Max Transaction Value By Risk](/test/client/token/invariant/accountMaxTxValueByRiskScore/RuleProcessingAccountMaxTxValueByRiskScoreMulti.t.i.sol)
 
@@ -66,7 +66,7 @@ All invariants have links to their invariant test files unless specified otherwi
 
 - When this rule is applied, an NFT can never be transferred before the hold-time period has passed counting from the last trade date.
 
-## Rule Invariants - Withour Stat Variables
+## Rule Invariants - Without Stat Variables
 
 ### Balance By Access Level *
 

--- a/test/client/token/ERC20/invariant/ApplicationERC20Basic.t.i.sol
+++ b/test/client/token/ERC20/invariant/ApplicationERC20Basic.t.i.sol
@@ -40,7 +40,7 @@ contract ApplicationERC20BasicInvariantTest is ApplicationERC20Common {
         assertEq(balance, applicationCoin.balanceOf((msgSender)));
     }
 
-    // Transfers to zero address should not be allowed
+    // transferFroms to zero address should not be allowed
     function invariant_ERC20external_transferFromToZeroAddress() public {
         if (applicationCoin.paused()) return;
         uint256 balance_sender = applicationCoin.balanceOf(msg.sender);
@@ -65,7 +65,7 @@ contract ApplicationERC20BasicInvariantTest is ApplicationERC20Common {
         assertEq(balance_sender, applicationCoin.balanceOf(msg.sender));
     }
 
-    // Self transfers should not break accounting
+    // Self transferFroms should not break accounting
     function invariant_ERC20external_selfTransfer() public {
         if (applicationCoin.paused()) return;
         uint256 balance_sender = applicationCoin.balanceOf(address(this));
@@ -90,7 +90,7 @@ contract ApplicationERC20BasicInvariantTest is ApplicationERC20Common {
         assertEq(applicationCoin.balanceOf(target), balance_receiver);
     }
 
-    // Transfers for more than available balance should not be allowed
+    // TransferFroms for more than available balance should not be allowed
     function invariant_ERC20external_transferMoreThanBalance() public {
         if (applicationCoin.paused()) return;
         uint256 balance_sender = applicationCoin.balanceOf(address(this));
@@ -116,7 +116,7 @@ contract ApplicationERC20BasicInvariantTest is ApplicationERC20Common {
         assertEq(applicationCoin.balanceOf(target), balance_receiver);
     }
 
-    // Zero amount transfers should not break accounting
+    // Zero amount transferFroms should not break accounting
     function invariant_ERC20external_transferFromZeroAmount() public {
         if (applicationCoin.paused()) return;
         uint256 balance_sender = applicationCoin.balanceOf(msg.sender);
@@ -145,7 +145,7 @@ contract ApplicationERC20BasicInvariantTest is ApplicationERC20Common {
         assertEq(applicationCoin.balanceOf(target), balance_receiver + transfer_value);
     }
 
-    // Transfers should update accounting correctly
+    // TransferFroms should update accounting correctly
     function invariant_ERC20external_transferFrom() public {
         if (!(target != address(this))) return;
         if (!(target != msg.sender)) return;
@@ -169,7 +169,7 @@ contract ApplicationERC20BasicInvariantTest is ApplicationERC20Common {
         assertEq(applicationCoin.allowance(address(this), target), amount);
     }
 
-    // Approve should set correct allowances
+    // Allowances should be updated correctly when approve is called twice.
     function invariant_ERC20external_setAllowanceTwice() public {
         if (applicationCoin.paused()) return;
         bool r = applicationCoin.approve(target, amount);

--- a/test/client/token/ERC20/invariant/ApplicationERC20MintBurn.t.i.sol
+++ b/test/client/token/ERC20/invariant/ApplicationERC20MintBurn.t.i.sol
@@ -34,7 +34,7 @@ contract ApplicationERC20MintBurnInvariantTest is ApplicationERC20Common {
         );
     }
 
-    // Burn should update user balance and total supply
+    // Burn should update user balance and total supply when burnFrom is called twice
     function invariant_ERC20external_burnFrom() public {
         if (applicationCoin.paused())return;
         uint256 balance_sender = applicationCoin.balanceOf(USER1);

--- a/test/client/token/ERC20/invariant/ApplicationERC20Pause.t.i.sol
+++ b/test/client/token/ERC20/invariant/ApplicationERC20Pause.t.i.sol
@@ -13,7 +13,7 @@ contract ApplicationERC20PauseInvariantTest is ApplicationERC20Common {
         prepERC20AndEnvironment();
     }
 
-// Transfers should not be possible during paused state
+    // Transfers should not be possible during paused state
     function invariant_ERC20external_pausedTransfer() public {
         (, msgSender, ) = vm.readCallers();
         uint256 balance_sender = applicationCoin.balanceOf(USER1);
@@ -39,7 +39,7 @@ contract ApplicationERC20PauseInvariantTest is ApplicationERC20Common {
         applicationCoin.unpause();
     }
 
-    // Transfers should not be possible during paused state
+    // TransferFroms should not be possible during paused state
     function invariant_ERC20external_pausedTransferFrom() public {
         uint256 balance_sender = applicationCoin.balanceOf(USER1);
         uint256 balance_receiver = applicationCoin.balanceOf(target);

--- a/test/client/token/ERC721/invariant/ApplicationERC721Base.t.i.sol
+++ b/test/client/token/ERC721/invariant/ApplicationERC721Base.t.i.sol
@@ -15,25 +15,25 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
     }
 
 
-    // Querying the balance of address(0) should throw
+    // Calling balanceOf for the zero address should revert.
     function invariant_ERC721_external_balanceOfZeroAddressMustRevert() public virtual {
         vm.expectRevert("ERC721: address zero is not a valid owner");
         applicationNFT.balanceOf(address(0));
     }
 
-    // Querying the owner of an invalid token should throw
+    // Calling ownerOf for an invalid token should revert.
     function invariant_ERC721_external_ownerOfInvalidTokenMustRevert() public {
         vm.expectRevert("ERC721: invalid token ID");
         applicationNFT.ownerOf(type(uint256).max);
     }
 
-    // Approving an invalid token should throw
+    // approve() should revert on invalid token.
     function invariant_ERC721_external_approvingInvalidTokenMustRevert() public {
         vm.expectRevert("ERC721: invalid token ID");
         applicationNFT.approve(address(0), type(uint256).max);
     }
 
-    // transferFrom a token that the caller is not approved for should revert
+    // transferFrom() should revert if caller is not approved.
     function invariant_ERC721_external_transferFromNotApproved() public {
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
         if(!(selfBalance > 0))return;        
@@ -46,7 +46,7 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
         applicationNFT.transferFrom(USER1, target, tokenId2);
     }
 
-    // transferFrom should reset approval for that token
+    // transferFrom() should reset approval for that token
     function invariant_ERC721_external_transferFromResetApproval() public virtual {
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
         if(!(selfBalance > 0)) return;  
@@ -64,7 +64,7 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
         assertTrue(approved == address(0));
     }
 
-    // transferFrom correctly updates owner
+    // transferFrom() should update the token owner.
     function invariant_ERC721_external_transferFromUpdatesOwner() public virtual {
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
         if(!(selfBalance > 0))return;  
@@ -81,7 +81,7 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
         }
     }
 
-    // transfer from zero address should revert
+    // transferFrom() should revert if from is the zero address.
     function invariant_ERC721_external_transferFromZeroAddress() public virtual {
         try applicationNFT.ownerOf(tokenId) {
             vm.expectRevert("ERC721: caller is not token owner or approved");
@@ -92,7 +92,7 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
         }
     }
 
-    // Transfers to the zero address should revert
+    // transferFrom() should revert if to is the zero address.
     function invariant_ERC721_external_transferToZeroAddress() public virtual {
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
         if(!(selfBalance > 0))return; 
@@ -104,7 +104,7 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
 
     }
 
-    // Transfers to self should not break accounting
+    // transferFrom() to self should not break accounting
     function invariant_ERC721_external_transferFromSelf() public virtual {
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
         if(!(selfBalance > 0))return; 
@@ -120,7 +120,7 @@ contract ApplicationERC721BasicInvariantTest is ApplicationERC721Common {
 
     }
 
-    // Transfer to self reset approval
+    // transferFrom() to self should reset approval
     function invariant_ERC721_external_transferFromSelfResetsApproval() public virtual {
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
         if(!(selfBalance > 0))return; 

--- a/test/client/token/ERC721/invariant/ApplicationERC721MintBurn.t.i.sol
+++ b/test/client/token/ERC721/invariant/ApplicationERC721MintBurn.t.i.sol
@@ -43,6 +43,7 @@ contract ApplicationERC721MintBurnInvariantTest is ApplicationERC721Common {
         applicationNFT.transferFrom(USER1, target, tokenId2);
     }
 
+    // approve() should revert if the token is burned
     function invariant_ERC721_external_burnRevertOnApprove() public virtual {
         if (applicationNFT.paused())return;
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
@@ -55,6 +56,7 @@ contract ApplicationERC721MintBurnInvariantTest is ApplicationERC721Common {
         applicationNFT.approve(USER1, tokenId2);
     }
 
+    // getApproved() should revert if the token is burned.
     function invariant_ERC721_external_burnRevertOnGetApproved() public virtual {
         if (applicationNFT.paused())return;
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
@@ -67,6 +69,7 @@ contract ApplicationERC721MintBurnInvariantTest is ApplicationERC721Common {
         applicationNFT.getApproved(tokenId2);
     }
 
+    // ownerOf() should revert if the token has been burned.
     function invariant_ERC721_external_burnRevertOnOwnerOf() public virtual {
         if (applicationNFT.paused())return;
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
@@ -80,7 +83,7 @@ contract ApplicationERC721MintBurnInvariantTest is ApplicationERC721Common {
     }
 
 /** MINT */
-    // mint increases the total supply.
+    // Mint increases the total supply.
     function invariant_ERC721_external_mintIncreasesSupply() public virtual {
         if (applicationNFT.paused())return;
         uint256 selfBalance = applicationNFT.balanceOf(USER1);
@@ -94,7 +97,7 @@ contract ApplicationERC721MintBurnInvariantTest is ApplicationERC721Common {
         }
     }
 
-    // mint creates a fresh applicationNFT.
+    // Mint creates a fresh applicationNFT.
     function invariant_ERC721_external_mintCreatesFreshToken() public virtual {
         if (applicationNFT.paused())return;
         switchToAppAdministrator();


### PR DESCRIPTION
This adds more clarification around the invariant documentation, attempts to deduplicate from the docs wherever possible, establish the proper links and clarify where tests for invariants are implemented and where they are not. 