### PR TITLE
We need Pt4 of the deploy all modules scripts here as well...

### DIFF
--- a/install-forge.sh
+++ b/install-forge.sh
@@ -19,6 +19,7 @@ if [ $SCRIPT_MODE = "--with-deploy" ]; then
 	source script/ParseProtocolDeploy.sh
 	forge script script/DeployAllModulesPt2.s.sol --ffi --broadcast
 	forge script script/DeployAllModulesPt3.s.sol --ffi --broadcast
+  	forge script script/DeployAllModulesPt4.s.sol --ffi --broadcast
 	forge script script/clientScripts/Application_Deploy_01_AppManager.s.sol --ffi --broadcast
 	source script/ParseApplicationDeploy.sh 1
 	forge script script/clientScripts/Application_Deploy_02_ApplicationFT1.s.sol --ffi --broadcast 


### PR DESCRIPTION
Simple change to add DeployAllModulesPt4 to the DOOM deploy stack, rather than just the "deploy check" process. 

Let's refactor install-forge.sh and install-deploy-check.sh so that they share code for this step, eh? Then we don't have this happen again. 