### PR TITLE
SE-756-Remove-indexed-keyword-from-the-AD1467_ApplicationRuleAppliedFull-event

### DIFF
--- a/docs/userGuides/rules/ACCOUNT-DENY-FOR-NO-ACCESS-LEVEL.md
+++ b/docs/userGuides/rules/ACCOUNT-DENY-FOR-NO-ACCESS-LEVEL.md
@@ -105,7 +105,7 @@ This rule doesn't require of any data to be recorded.
         - ruleType: "ACCOUNT_DENY_FOR_NO_ACCESS_LEVEL".
         - action: the protocol action the rule is being applied to.
         - ruleId: the ruleId set for this rule in the handler.
-- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] indexed ruleIds);**:
+- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] ruleIds);**:
     - Emitted when: rule has been applied in an application manager handler.
     - Parameters: 
         - ruleType: "ACCOUNT_DENY_FOR_NO_ACCESS_LEVEL".

--- a/docs/userGuides/rules/ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md
+++ b/docs/userGuides/rules/ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md
@@ -242,7 +242,7 @@ mapping(address => uint64) lastTxDateRiskRule;
         - ruleType: "ACC_MAX_TX_VALUE_BY_RISK_SCORE".
         - action: the protocol action the rule is being applied to.
         - ruleId: the ruleId set for this rule in the handler.
-- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] indexed ruleIds);**:
+- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] ruleIds);**:
     - Emitted when: rule has been applied in an application manager handler.
     - Parameters: 
         - ruleType: "ACC_MAX_TX_VALUE_BY_RISK_SCORE".

--- a/docs/userGuides/rules/ACCOUNT-MAX-VALUE-BY-ACCESS-LEVEL.md
+++ b/docs/userGuides/rules/ACCOUNT-MAX-VALUE-BY-ACCESS-LEVEL.md
@@ -187,7 +187,7 @@ This rule doesn't require of any data to be recorded.
         - action: the protocol action the rule is being applied to.
         - ruleId: the ruleId set for this rule in the handler.
 
-- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] indexed ruleIds);**:
+- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] ruleIds);**:
     - Emitted when: rule has been applied in an application manager handler.
     - Parameters: 
         - ruleType: "ACC_MAX_VALUE_BY_ACCESS_LEVEL".

--- a/docs/userGuides/rules/ACCOUNT-MAX-VALUE-BY-RISK.md
+++ b/docs/userGuides/rules/ACCOUNT-MAX-VALUE-BY-RISK.md
@@ -207,7 +207,7 @@ This rule does not require any data to be recorded.
         - handlerAddress: the address of the application handler where the rule has been applied.
         - ruleId: the index of the rule created in the protocol by rule type.
 
-- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] indexed ruleIds);**:
+- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] ruleIds);**:
     - Emitted when: rule has been applied in an application manager handler.
     - Parameters: 
         - ruleType: "BALANCE_BY_RISK".

--- a/docs/userGuides/rules/ACCOUNT-MAX-VALUE-OUT-BY-ACCESS-LEVEL.md
+++ b/docs/userGuides/rules/ACCOUNT-MAX-VALUE-OUT-BY-ACCESS-LEVEL.md
@@ -204,7 +204,7 @@ This rule requires recording of the following information in the application han
         - action: the protocol action the rule is being applied to.
         - ruleId: the ruleId set for this rule in the handler.
   
-- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] indexed ruleIds);**:
+- **event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] ruleIds);**:
     - Emitted when: rule has been applied in an application manager handler.
     - Parameters: 
         - ruleType: "ACC_MAX_VALUE_OUT_ACCESS_LEVEL".

--- a/src/common/IEvents.sol
+++ b/src/common/IEvents.sol
@@ -80,7 +80,7 @@ interface IApplicationHandlerEvents {
     // Rule applied
     event AD1467_ApplicationRuleApplied(bytes32 indexed ruleType, uint32 indexed ruleId);
     event AD1467_ApplicationRuleApplied(bytes32 indexed ruleType, ActionTypes indexed action, uint32 indexed ruleId);
-    event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] indexed action, uint32[] indexed ruleId);
+    event AD1467_ApplicationRuleAppliedFull(bytes32 indexed ruleType, ActionTypes[] actions, uint32[] ruleIds);
     /// Pricing
     event AD1467_ERC721PricingAddressSet(address indexed _address);
     event AD1467_ERC20PricingAddressSet(address indexed _address);


### PR DESCRIPTION
Removed indexed keyword from AD1467_ApplicationRuleAppliedFull. Also pluralized ActionType array and ruleId array to match some docs.