### PR TITLE
SE-783-Resolve-Audit-finding-Number-5-Fix-renounce-role-for-Treasury-formerly-RuleBypass-

### DIFF
--- a/docs/userGuides/README.md
+++ b/docs/userGuides/README.md
@@ -194,9 +194,6 @@ Once you have deployed your smart contracts, you can monitor them using [Openzep
 | AD1467_HandlerConnected | "ApplicationAppManager/ProtocolERC20{U}/ProtocolERC721{U}"  | Emits whenever a handler is connected, whether that be an application handler or a token handler |
 | AD1467_AppManagerDeployed | ApplicationAppManager | Emits whenever a new application manager is deployed |
 | AD1467_AppManagerDeployedForUpgrade |	ApplicationAppManager | Emits whenever a new application manager is deployed as an upgrade to a previous application manager |
-| AD1467_AppAdministrator | ApplicationAppManager | Emits whenever an application administrator is set |
-| AD1467_SuperAdministrator |	ApplicationAppManager | Emits whenever a super administrator is set |
-| AD1467_TreasuryAccount	| ApplicationAppManager | Emits whenever a treasury account role is set or removed |
 | AD1467_ApplicationHandlerDeployed	| ApplicationHandler | Emits whenever a new application handler is deployed |
 | AD1467_ERC721PricingAddressSet	| ApplicationHandler | Emits whenever an ERC721 pricer is set |
 | AD1467_ERC20PricingAddressSet	| ApplicationHandler | Emits whenever an ERC20 pricer is set |

--- a/docs/userGuides/architecture/client/application/APPLICATION-MANAGER.md
+++ b/docs/userGuides/architecture/client/application/APPLICATION-MANAGER.md
@@ -43,9 +43,9 @@ Adds the provided address as a new App Admin for the application. This function 
 A utility method to add multiple App Admins at the same time. Like the singular version this can only be called by the existing Super Admin.
 
 ```c
-function renounceAppAdministrator() external
+function renounceRole(bytes32 role, address account) external
 ```
-Removes the senders role as an App Admin.
+Removes the senders role as an App Admin if the role argument is APP_ADMIN_ROLE
 
 
 ##### Super Admin Special Case

--- a/docs/userGuides/development/invariants/client/application/AppManager-Invariants.md
+++ b/docs/userGuides/development/invariants/client/application/AppManager-Invariants.md
@@ -7,23 +7,23 @@
 - When addAppAdministrator is called by an account other than the Super Admin the transaction will be reverted.
 - When addAppAdministrator is called with an address of 0 the transaction will be reverted.
 - If addAppAdministrator is not reverted the AppAdministrator event will be emitted. 
-- When renounceAppAdministrator is called the AppAdministrator event will be emitted.
+- When renounceRole is called with argument APP_ADMIN_ROLE the AppAdministrator event will be emitted.
 - When addRuleAdministrator is called by an account other other than an App Admin the transaction will be reverted.
 - When addRuleAdministrator is called with an address of 0 the transaction will be reverted.
 - If addRuleAdministrator is not reverted the RuleAdmin event will be emitted.
-- When renounceRuleAdministrator is called the RuleAdministrator event will be emitted.
+- When renounceRole is called with argument RULE_ADMIN_ROLE the RuleAdministrator event will be emitted.
 - When addRiskAdmin is called by an account other than an App Admin the transaction will be reverted.
 - When addRiskAdmin is called with an address of 0 the transaction will be reverted.
 - If addRiskAdmin is not reverted the RiskAdmin event will be emitted.
-- When renounceRiskAdmin is called the RiskAdmin event will be emitted.
+- When renounceRole is called with argument RISK_ADMIN_ROLE the RiskAdmin event will be emitted.
 - When addTreasuryAccount is called by an account other than an App Admin the transaction will be reverted.
 - When addTreasuryAccount is called with an address of 0 the transaction will be reverted.
 - If addTreasuryAccount is not reverted the TreasuryAccount event will be emitted.
-- When renounceTreasuryAccount is called the TreasuryAccount event will be emitted.
+- When renounceRole is called with argument TREASURY_ACCOUNT the TreasuryAccount event will be emitted.
 - When addAccessLevelAdmin is called by an account other than an App Admin the transaction will be reverted.
 - When addAccessLevelAdmin is called with an address of 0 the transaction will be reverted.
 - If addAccessLevelAdmin is not reverted the AccessLevelAdmin event will be emitted.
-- When renounceAccessLevelAdmin is called the AccessLevelAdmin event will be emitted.
+- When renounceRole is called with argument ACCESS_LEVEL_ADMIN_ROLE the AccessLevelAdmin event will be emitted.
   
 
 ## [Access Level Invariants](../../../../../../test/client/application/invariant/ApplicationAppManagerData.t.i.sol)

--- a/src/client/application/AppManager.sol
+++ b/src/client/application/AppManager.sol
@@ -119,6 +119,12 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         /// enforcing the min-1-admin requirement. Only PROPOSED_SUPER_ADMIN_ROLE should be able to bypass this rule
         if (role == SUPER_ADMIN_ROLE) revert BelowMinAdminThreshold();
         AccessControl.renounceRole(role, account);
+
+        if (role == APP_ADMIN_ROLE) emit AD1467_AppAdministrator(_msgSender(), false);
+        if (role == RULE_ADMIN_ROLE) emit AD1467_RuleAdmin(_msgSender(), false);
+        if (role == TREASURY_ACCOUNT) emit AD1467_TreasuryAccount(_msgSender(), false);
+        if (role == ACCESS_LEVEL_ADMIN_ROLE) emit AD1467_AccessLevelAdmin(_msgSender(), false);
+        if (role == RISK_ADMIN_ROLE) emit AD1467_RiskAdmin(_msgSender(), false);
     }
 
     /**
@@ -218,14 +224,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         }
     }
 
-    /**
-     * @dev Remove oneself from the app administrator role.
-     */
-    function renounceAppAdministrator() external {
-        renounceRole(APP_ADMIN_ROLE, _msgSender());
-        emit AD1467_AppAdministrator(_msgSender(), false);
-    }
-
     /// -------------RULE ADMIN---------------
 
     /**
@@ -255,14 +253,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         for (uint256 i; i < account.length; ++i) {
             addRuleAdministrator(account[i]);
         }
-    }
-
-    /**
-     * @dev Remove oneself from the rule admin role.
-     */
-    function renounceRuleAdministrator() external {
-        renounceRole(RULE_ADMIN_ROLE, _msgSender());
-        emit AD1467_RuleAdmin(_msgSender(), false);
     }
 
     /// -------------TREASURY ACCOUNT ---------------
@@ -296,19 +286,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         }
     }
 
-    /**
-     * @dev Remove oneself from the Treasury account role.
-     * @notice This function renounces the Treasury Account role.
-     */
-    function renounceTreasuryAccount() external nonReentrant {
-        // Disabling this finding, it is a false positive. A reentrancy lock modifier has been
-        // applied to this function
-        // slither-disable-next-line reentrancy-benign
-        renounceRole(TREASURY_ACCOUNT, _msgSender());
-        // slither-disable-next-line reentrancy-events
-        emit AD1467_TreasuryAccount(_msgSender(), false);
-    }
-
     /// -------------ACCESS LEVEL---------------
     /**
      * @dev This function is where the access level admin role is actually checked
@@ -337,14 +314,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         for (uint256 i; i < account.length; ++i) {
             addAccessLevelAdmin(account[i]);
         }
-    }
-
-    /**
-     * @dev Remove oneself from the access level role.
-     */
-    function renounceAccessLevelAdmin() external {
-        renounceRole(ACCESS_LEVEL_ADMIN_ROLE, _msgSender());
-        emit AD1467_AccessLevelAdmin(_msgSender(), false);
     }
 
     /// -------------RISK ADMIN---------------
@@ -376,14 +345,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         for (uint256 i; i < account.length; ++i) {
             addRiskAdmin(account[i]);
         }
-    }
-
-    /**
-     * @dev Remove oneself from the risk admin role.
-     */
-    function renounceRiskAdmin() external {
-        renounceRole(RISK_ADMIN_ROLE, _msgSender());
-        emit AD1467_RiskAdmin(_msgSender(), false);
     }
 
     /// -------------MAINTAIN ACCESS LEVELS---------------

--- a/src/client/application/AppManager.sol
+++ b/src/client/application/AppManager.sol
@@ -119,12 +119,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         /// enforcing the min-1-admin requirement. Only PROPOSED_SUPER_ADMIN_ROLE should be able to bypass this rule
         if (role == SUPER_ADMIN_ROLE) revert BelowMinAdminThreshold();
         AccessControl.renounceRole(role, account);
-
-        if (role == APP_ADMIN_ROLE) emit AD1467_AppAdministrator(_msgSender(), false);
-        if (role == RULE_ADMIN_ROLE) emit AD1467_RuleAdmin(_msgSender(), false);
-        if (role == TREASURY_ACCOUNT) emit AD1467_TreasuryAccount(_msgSender(), false);
-        if (role == ACCESS_LEVEL_ADMIN_ROLE) emit AD1467_AccessLevelAdmin(_msgSender(), false);
-        if (role == RISK_ADMIN_ROLE) emit AD1467_RiskAdmin(_msgSender(), false);
     }
 
     /**
@@ -189,8 +183,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
         super.grantRole(SUPER_ADMIN_ROLE, newSuperAdmin);
         super.revokeRole(SUPER_ADMIN_ROLE, oldSuperAdmin);
         renounceRole(PROPOSED_SUPER_ADMIN_ROLE, _msgSender());
-        emit AD1467_SuperAdministrator(_msgSender(), true);
-        emit AD1467_SuperAdministrator(oldSuperAdmin, false);
     }
 
     /// -------------APP ADMIN---------------
@@ -211,7 +203,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
     function addAppAdministrator(address account) public onlyRole(SUPER_ADMIN_ROLE) {
         if (account == address(0)) revert ZeroAddress();
         super.grantRole(APP_ADMIN_ROLE, account);
-        emit AD1467_AppAdministrator(account, true);
     }
 
     /**
@@ -242,7 +233,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
     function addRuleAdministrator(address account) public onlyRole(APP_ADMIN_ROLE) {
         if (account == address(0)) revert ZeroAddress();
         super.grantRole(RULE_ADMIN_ROLE, account);
-        emit AD1467_RuleAdmin(account, true);
     }
 
     /**
@@ -273,7 +263,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
     function addTreasuryAccount(address account) public onlyRole(APP_ADMIN_ROLE) {
         if (account == address(0)) revert ZeroAddress();
         super.grantRole(TREASURY_ACCOUNT, account);
-        emit AD1467_TreasuryAccount(account, true);
     }
 
     /**
@@ -303,7 +292,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
     function addAccessLevelAdmin(address account) public onlyRole(APP_ADMIN_ROLE) {
         if (account == address(0)) revert ZeroAddress();
         super.grantRole(ACCESS_LEVEL_ADMIN_ROLE, account);
-        emit AD1467_AccessLevelAdmin(account, true);
     }
 
     /**
@@ -334,7 +322,6 @@ contract AppManager is IAppManager, AccessControlEnumerable, IAppLevelEvents, IA
     function addRiskAdmin(address account) public onlyRole(APP_ADMIN_ROLE) {
         if (account == address(0)) revert ZeroAddress();
         super.grantRole(RISK_ADMIN_ROLE, account);
-        emit AD1467_RiskAdmin(account, true);
     }
 
     /**

--- a/src/common/IEvents.sol
+++ b/src/common/IEvents.sol
@@ -21,12 +21,6 @@ interface IAppLevelEvents {
     event AD1467_AppManagerDataUpgradeProposed(address indexed deployedAddress, address replacedAddress);
     event AD1467_DataContractsMigrated(address indexed ownerAddress);
     event AD1467_RemoveFromRegistry(string contractName, address contractAddress);
-    event AD1467_RuleAdmin(address indexed admin, bool indexed add);
-    event AD1467_RiskAdmin(address indexed admin, bool indexed add);
-    event AD1467_AccessLevelAdmin(address indexed admin, bool indexed add);
-    event AD1467_AppAdministrator(address indexed admin, bool indexed add); 
-    event AD1467_SuperAdministrator(address indexed admin, bool indexed add);
-    event AD1467_TreasuryAccount(address indexed treasuryAccount, bool indexed add);
     event AD1467_AppNameChanged(string indexed appName);  
     ///Registrations
     event AD1467_TokenRegistered(string indexed _token, address indexed _address);

--- a/test/client/application/ApplicationCommonTests.t.sol
+++ b/test/client/application/ApplicationCommonTests.t.sol
@@ -100,7 +100,9 @@ abstract contract ApplicationCommonTests is Test, TestCommonFoundry, ERC721Util 
         assertEq(applicationAppManager.isAppAdministrator(appAdministrator), true);
         assertEq(applicationAppManager.hasRole(APP_ADMIN_ROLE, appAdministrator), true); // verify it was added as an app administrator
         /// we renounce so there can be only one appAdmin
-        applicationAppManager.renounceAppAdministrator();
+        vm.startPrank(appAdministrator);
+        applicationAppManager.renounceRole(APP_ADMIN_ROLE, appAdministrator);
+        switchToSuperAdmin();
         applicationAppManager.revokeRole(APP_ADMIN_ROLE, appAdministrator);
         assertEq(applicationAppManager.isAppAdministrator(appAdministrator), false);
     }
@@ -113,7 +115,7 @@ abstract contract ApplicationCommonTests is Test, TestCommonFoundry, ERC721Util 
 
     function testApplication_ApplicationCommonTests_RenounceAppAdministrator() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToAppAdministrator();
-        applicationAppManager.renounceAppAdministrator();
+        applicationAppManager.renounceRole(APP_ADMIN_ROLE, appAdministrator);
         assertFalse(applicationAppManager.isAppAdministrator(appAdministrator));
     }
 
@@ -137,7 +139,7 @@ abstract contract ApplicationCommonTests is Test, TestCommonFoundry, ERC721Util 
 
     function testApplication_ApplicationCommonTests_RenounceRiskAdmin() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToRiskAdmin(); //interact as the created risk admin
-        applicationAppManager.renounceRiskAdmin();
+        applicationAppManager.renounceRole(RISK_ADMIN_ROLE, riskAdmin);
         assertFalse(applicationAppManager.isRiskAdmin(riskAdmin));
     }
 
@@ -171,7 +173,7 @@ abstract contract ApplicationCommonTests is Test, TestCommonFoundry, ERC721Util 
 
     function testApplication_ApplicationCommonTests_RenounceAccessLevelAdmin() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToAccessLevelAdmin();
-        applicationAppManager.renounceAccessLevelAdmin();
+        applicationAppManager.renounceRole(ACCESS_LEVEL_ADMIN_ROLE, accessLevelAdmin);
         assertFalse(applicationAppManager.isAccessLevelAdmin(accessLevelAdmin));
     }
 

--- a/test/client/application/ApplicationCommonTests.t.sol
+++ b/test/client/application/ApplicationCommonTests.t.sol
@@ -494,36 +494,36 @@ abstract contract ApplicationCommonTests is Test, TestCommonFoundry, ERC721Util 
     function testApplication_ApplicationCommonTests_RuleAdminEventEmission() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToAppAdministrator();
         vm.expectEmit(true, true, false, false);
-        emit AD1467_RuleAdmin(ruleAdmin, true);
-        applicationAppManager.addRuleAdministrator(ruleAdmin);
+        emit RoleGranted(RULE_ADMIN_ROLE, user, appAdministrator);
+        applicationAppManager.addRuleAdministrator(user);
     }
 
     function testApplication_ApplicationCommonTests_RiskAdminEventEmission() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToAppAdministrator();
         vm.expectEmit(true, true, false, false);
-        emit AD1467_RiskAdmin(riskAdmin, true);
-        applicationAppManager.addRiskAdmin(riskAdmin);
+        emit RoleGranted(RISK_ADMIN_ROLE, user, appAdministrator);
+        applicationAppManager.addRiskAdmin(user);
     }
 
     function testApplication_ApplicationCommonTests_AccessLevelAdminEventEmission() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToAppAdministrator();
         vm.expectEmit(true, true, false, false);
-        emit AD1467_AccessLevelAdmin(accessLevelAdmin, true);
-        applicationAppManager.addAccessLevelAdmin(accessLevelAdmin);
+        emit RoleGranted(ACCESS_LEVEL_ADMIN_ROLE, user, appAdministrator);
+        applicationAppManager.addAccessLevelAdmin(user);
     }
 
     function testApplication_ApplicationCommonTests_AppAdminEventEmission() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToSuperAdmin();
         vm.expectEmit(true, true, false, false);
-        emit AD1467_AppAdministrator(appAdministrator, true);
-        applicationAppManager.addAppAdministrator(appAdministrator);
+        emit RoleGranted(APP_ADMIN_ROLE, user, superAdmin);
+        applicationAppManager.addAppAdministrator(user);
     }
 
     function testApplication_ApplicationCommonTests_TreasuryAccountEventEmission() public endWithStopPrank ifDeploymentTestsEnabled {
         switchToAppAdministrator();
         vm.expectEmit(true, true, false, false);
-        emit AD1467_TreasuryAccount(treasuryAccount, true);
-        applicationAppManager.addTreasuryAccount(treasuryAccount);
+        emit RoleGranted(TREASURY_ACCOUNT, user, appAdministrator);
+        applicationAppManager.addTreasuryAccount(user);
     }
 
     function testApplication_ApplicationCommonTests_AppNameEventEmission() public endWithStopPrank ifDeploymentTestsEnabled {

--- a/test/client/application/fuzz/ApplicationAppManagerFuzz.t.sol
+++ b/test/client/application/fuzz/ApplicationAppManagerFuzz.t.sol
@@ -140,7 +140,7 @@ contract ApplicationAppManagerFuzzTest is TestCommonFoundry {
             assertTrue(applicationAppManager.hasRole(APP_ADMIN_ROLE, admin)); // verify it was added as a app administrator
             vm.stopPrank();
             vm.startPrank(admin);
-            applicationAppManager.renounceAppAdministrator();
+            applicationAppManager.renounceRole(APP_ADMIN_ROLE, admin);
             assertFalse(applicationAppManager.isAppAdministrator(admin));
         }
     }
@@ -258,7 +258,7 @@ contract ApplicationAppManagerFuzzTest is TestCommonFoundry {
             assertFalse(applicationAppManager.isRiskAdmin(address(88)));
             vm.stopPrank(); //stop interacting as the app administrator
             vm.startPrank(random); //interact as the created risk admin
-            applicationAppManager.renounceRiskAdmin();
+            applicationAppManager.renounceRole(RISK_ADMIN_ROLE, random);
             assertFalse(applicationAppManager.isRiskAdmin(random));
         }
     }
@@ -354,7 +354,7 @@ contract ApplicationAppManagerFuzzTest is TestCommonFoundry {
             assertFalse(applicationAppManager.isAccessLevelAdmin(address(88)));
             vm.stopPrank();
             vm.startPrank(random);
-            applicationAppManager.renounceAccessLevelAdmin();
+            applicationAppManager.renounceRole(ACCESS_LEVEL_ADMIN_ROLE, random);
             assertFalse(applicationAppManager.isAccessLevelAdmin(random));
         }
     }

--- a/test/client/application/invariant/ApplicationAppManagerRoles.t.i.sol
+++ b/test/client/application/invariant/ApplicationAppManagerRoles.t.i.sol
@@ -88,7 +88,7 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
         switchToAppAdministrator();
         vm.expectEmit();
         emit AD1467_AppAdministrator(appAdministrator, false);
-        applicationAppManager.renounceAppAdministrator();
+        applicationAppManager.renounceRole(APP_ADMIN_ROLE, appAdministrator);
     }
 
     /** RULE ADMIN */
@@ -124,7 +124,7 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
         switchToRuleAdmin();
         vm.expectEmit();
         emit AD1467_RuleAdmin(ruleAdmin, false);
-        applicationAppManager.renounceRuleAdministrator();
+        applicationAppManager.renounceRole(RULE_ADMIN_ROLE, ruleAdmin);
     }
 
     /** RISK ADMIN */
@@ -160,7 +160,7 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
         switchToRiskAdmin();
         vm.expectEmit();
         emit AD1467_RiskAdmin(riskAdmin, false);
-        applicationAppManager.renounceRiskAdmin();
+        applicationAppManager.renounceRole(RISK_ADMIN_ROLE, riskAdmin);
     }
 
     /** ACCESS LEVEL ADMIN */
@@ -196,7 +196,7 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
         switchToAccessLevelAdmin();
         vm.expectEmit();
         emit AD1467_AccessLevelAdmin(accessLevelAdmin, false);
-        applicationAppManager.renounceAccessLevelAdmin();
+        applicationAppManager.renounceRole(ACCESS_LEVEL_ADMIN_ROLE, accessLevelAdmin);
     }
 
     /** TREASURY ACCOUNT   */
@@ -232,7 +232,7 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
         switchToTreasuryAccount();
         vm.expectEmit();
         emit AD1467_TreasuryAccount(treasuryAccount, false);
-        applicationAppManager.renounceTreasuryAccount();
+        applicationAppManager.renounceRole(TREASURY_ACCOUNT, treasuryAccount);
     }
 
 }

--- a/test/client/application/invariant/ApplicationAppManagerRoles.t.i.sol
+++ b/test/client/application/invariant/ApplicationAppManagerRoles.t.i.sol
@@ -80,14 +80,14 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
     function invariant_AddAppAdministratorEmitsEvent() public {
         switchToSuperAdmin();
         vm.expectEmit();
-        emit AD1467_AppAdministrator(user, true);
+        emit RoleGranted(APP_ADMIN_ROLE, user, superAdmin);
         applicationAppManager.addAppAdministrator(user);
     }
-    // When renounceAppAdministrator is called the AppAdministrator event will be emitted.
+    // When renounceRole is called with argument APP_ADMIN_ROLE the AccessControl.RoleRevoked event will be emitted.
     function invariant_RenounceAppAdministratorEmitsEvent() public {
         switchToAppAdministrator();
         vm.expectEmit();
-        emit AD1467_AppAdministrator(appAdministrator, false);
+        emit RoleRevoked(APP_ADMIN_ROLE, appAdministrator, appAdministrator);
         applicationAppManager.renounceRole(APP_ADMIN_ROLE, appAdministrator);
     }
 
@@ -116,14 +116,14 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
     function invariant_AddRuleAdministratorEmitsEvent() public {
         switchToAppAdministrator();
         vm.expectEmit();
-        emit AD1467_RuleAdmin(user, true);
+        emit RoleGranted(RULE_ADMIN_ROLE, user, appAdministrator);
         applicationAppManager.addRuleAdministrator(user);
     }
-    // When renounceRuleAdministrator is called the RuleAdministrator event will be emitted.
+    // When renounceRole is called with argument RULE_ADMIN_ROLE the AccessControl.RoleRevoked event will be emitted.
     function invariant_RenounceRuleAdministratorEmitsEvent() public {
         switchToRuleAdmin();
         vm.expectEmit();
-        emit AD1467_RuleAdmin(ruleAdmin, false);
+        emit RoleRevoked(RULE_ADMIN_ROLE, ruleAdmin, ruleAdmin);
         applicationAppManager.renounceRole(RULE_ADMIN_ROLE, ruleAdmin);
     }
 
@@ -152,14 +152,14 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
     function invariant_AddRiskAdminEmitsEvent() public {
         switchToAppAdministrator();
         vm.expectEmit();
-        emit AD1467_RiskAdmin(user, true);
+        emit RoleGranted(RISK_ADMIN_ROLE, user, appAdministrator);
         applicationAppManager.addRiskAdmin(user);
     }
-    // When renounceRiskAdmin is called the RiskAdmin event will be emitted.
+    // When renounceRole is called with argument RISK_ADMIN_ROLE the AccessControl.RoleRevoked event will be emitted.
     function invariant_RenounceRiskAdminEmitsEvent() public {
         switchToRiskAdmin();
         vm.expectEmit();
-        emit AD1467_RiskAdmin(riskAdmin, false);
+        emit RoleRevoked(RISK_ADMIN_ROLE, riskAdmin, riskAdmin);
         applicationAppManager.renounceRole(RISK_ADMIN_ROLE, riskAdmin);
     }
 
@@ -188,14 +188,14 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
     function invariant_AddAccessLevelAdminEmitsEvent() public {
         switchToAppAdministrator();
         vm.expectEmit();
-        emit AD1467_AccessLevelAdmin(user, true);
+        emit RoleGranted(ACCESS_LEVEL_ADMIN_ROLE, user, appAdministrator);
         applicationAppManager.addAccessLevelAdmin(user);
     }
-    // When renounceAccessLevelAdmin is called the AccessLevelAdmin event will be emitted.
+    // When renounceRole is called with argument ACCESS_LEVEL_ADMIN_ROLE the AccessControl.RoleRevoked event will be emitted.
     function invariant_RenounceAccessLevelAdminEmitsEvent() public {
         switchToAccessLevelAdmin();
         vm.expectEmit();
-        emit AD1467_AccessLevelAdmin(accessLevelAdmin, false);
+        emit RoleRevoked(ACCESS_LEVEL_ADMIN_ROLE, accessLevelAdmin, accessLevelAdmin);
         applicationAppManager.renounceRole(ACCESS_LEVEL_ADMIN_ROLE, accessLevelAdmin);
     }
 
@@ -224,14 +224,14 @@ contract ApplicationAppManagerRolesTest is TestCommonFoundry {
     function invariant_AddTreasuryAccountEmitsEvent() public {
         switchToAppAdministrator();
         vm.expectEmit();
-        emit AD1467_TreasuryAccount(user, true);
+        emit RoleGranted(TREASURY_ACCOUNT, user, appAdministrator);
         applicationAppManager.addTreasuryAccount(user);
     }
-    // When renounceTreasuryAccount is called the TreasuryAccount event will be emitted.
+    // When renounceRole is called with argument TREASURY_ACCOUNT the AccessControl.RoleRevoked event will be emitted.
     function invariant_RenounceTreasuryAccountEmitsEvent() public {
         switchToTreasuryAccount();
         vm.expectEmit();
-        emit AD1467_TreasuryAccount(treasuryAccount, false);
+        emit RoleRevoked(TREASURY_ACCOUNT, treasuryAccount, treasuryAccount);
         applicationAppManager.renounceRole(TREASURY_ACCOUNT, treasuryAccount);
     }
 

--- a/test/util/TestCommon.sol
+++ b/test/util/TestCommon.sol
@@ -174,6 +174,7 @@ abstract contract TestCommon is
     bytes32 public constant ACCESS_LEVEL_ADMIN_ROLE = keccak256("ACCESS_LEVEL_ADMIN_ROLE");
     bytes32 public constant RISK_ADMIN_ROLE = keccak256("RISK_ADMIN_ROLE");
     bytes32 public constant PROPOSED_SUPER_ADMIN_ROLE = keccak256("PROPOSED_SUPER_ADMIN_ROLE");
+    bytes32 public constant RULE_ADMIN_ROLE = keccak256("RULE_ADMIN_ROLE");
     uint8 public constant MAX_ACTION_TYPES = 4;
 
     /**

--- a/test/util/TestCommonFoundry.sol
+++ b/test/util/TestCommonFoundry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.17;
 import "test/util/TestCommon.sol";
 import "test/util/EndWithStopPrank.sol";
 import "script/EnabledActionPerRuleArray.sol";
+import "lib/openzeppelin-contracts/contracts/access/AccessControl.sol";
 
 /**
  * @title Test Common Foundry
@@ -13,7 +14,7 @@ import "script/EnabledActionPerRuleArray.sol";
  * create = set to proper user, deploy contracts, reset user, return the contract
  * _create = deploy contract, return the contract
  */
-abstract contract TestCommonFoundry is TestCommon, EndWithStopPrank, EnabledActionPerRuleArray {
+abstract contract TestCommonFoundry is TestCommon, EndWithStopPrank, EnabledActionPerRuleArray, AccessControl {
     modifier ifDeploymentTestsEnabled() {
         if (testDeployments) {
             _;


### PR DESCRIPTION
Removed specific role renounce functions, added specific role events to renounceRole. I have a sneaking suspicion that I've missed something due to the number of story points for this ticket. The ticket mentioned _This function can have the necessary safeguards to prevent the renouncement of certain roles given certain conditions._ but the only condition these specific role renounce functions had was the checkForAdminMinTokenBalanceCapable for the now treasury account, which has since been removed. Please let me know if there are certain condition checks that are missing in the renounceRole function.