### PR TITLE
Fix Test workflow pinning to release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
           submodules: recursive
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # May 2, 2024 - Must be a release (nightly) tag
+          version: nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9 
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
The GitHub Action Test Action uses foundry-rs/foundry-toolchain, which only supports setting version[ to a "release"](https://github.com/foundry-rs/foundry-toolchain/blob/master/src/utils.js#L16-L20). So I'm going to use May 2nd's nightly. I won't be surprised if this breaks at the end of the month.