### PR TITLE
1/3: Foundry install/update script

### DIFF
--- a/.github/PRChecklist.md
+++ b/.github/PRChecklist.md
@@ -32,7 +32,7 @@
 
    1. Make sure `foundry.lock` is set to an appropriate version, then update Foundry.
 
-      `foundryup --commit $(awk '$1~/^[^#]/' foundry.lock)`
+      `./foundry-version-check.sh`
 
    2. Generate the docs:
 

--- a/deployAppERC20Test.sh
+++ b/deployAppERC20Test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployAppERC20Test.sh
+++ b/deployAppERC20Test.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -17,14 +15,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
-# make sure that foundry is installed. If it is, update it to the specific version. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+
+./foundry-version-check.sh
 
 if [ -n $FOUNDRY_PROFILE ]; then
   RPC_URL="local"

--- a/deployAppERC721Test.sh
+++ b/deployAppERC721Test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployAppERC721Test.sh
+++ b/deployAppERC721Test.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -18,14 +16,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# make sure that foundry is installed. If it is, update it. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+./foundry-version-check.sh
 
 if [ -n $FOUNDRY_PROFILE ]; then
   RPC_URL="local"

--- a/deployAppManagerTest.sh
+++ b/deployAppManagerTest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployAppManagerTest.sh
+++ b/deployAppManagerTest.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -18,14 +16,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# make sure that foundry is installed. If it is, update it. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+./foundry-version-check.sh
 
 ##### VALIDATE and RETRIEVE Entry variables
 

--- a/deployProtocolTest.sh
+++ b/deployProtocolTest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployProtocolTest.sh
+++ b/deployProtocolTest.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -18,14 +16,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# make sure that foundry is installed. If it is, update it. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+./foundry-version-check.sh
 
 ##### VALIDATE and RETRIEVE Entry variables
 

--- a/foundry-version-check.sh
+++ b/foundry-version-check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+foundry_pinned_version=$(awk '!/^#/ {print $0; exit}' foundry.lock)
+# `forge --version` refers to the first 8 characters of the commit hash
+foundry_version_short=${foundry_pinned_version:0:8}
+skip_install=${SKIP_INSTALL:-false}
+flags=${1:-0}
+
+if [ $flags = "--skip-install" ]; then
+  skip_install=true
+fi
+
+function installed() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+function installed_current() {
+  command "$1" --version | grep "$foundry_version_short" >/dev/null 2>&1
+}
+
+if installed_current forge && installed_current anvil && installed_current cast; then
+  echo "✅ Foundry, Anvil, and Cast are already installed and up to date."
+  exit 0
+elif installed forge && installed anvil && installed cast; then
+  echo "🦖 Foundry is out of date."
+  if $skip_install; then
+    echo "--skip-install used. Skipping installation..."
+  else
+    echo "🚀 Updating Foundry..."
+    foundryup --commit $foundry_pinned_version
+  fi
+else
+  echo "❌ Foundry is not installed."
+  if $skip_install; then
+    echo "--skip-install used. Skipping installation..."
+  else
+    echo "🏗️ Installing Foundry..."
+    $(curl -L https://foundry.paradigm.xyz)
+  fi
+fi

--- a/foundry-version-check.sh
+++ b/foundry-version-check.sh
@@ -38,5 +38,6 @@ else
   else
     echo "🏗️ Installing Foundry..."
     $(curl -L https://foundry.paradigm.xyz)
+    foundryup --commit $foundry_pinned_version
   fi
 fi

--- a/install-forge.sh
+++ b/install-forge.sh
@@ -4,8 +4,9 @@ set -e
 SCRIPT_MODE=$1
 
 source ~/.bashrc
-# Pin foundry to a known-good commit hash. Awk ignores comments in `foundry.lock`
-foundryup --commit $(awk '$1~/^[^#]/' foundry.lock)
+# Ensures foundry is installed and up to date with foundry.lock
+./foundry-version-check.sh
+
 python3 -m venv .venv
 source .venv/bin/activate
 python3 -m pip install -r requirements.txt

--- a/install-forge.sh
+++ b/install-forge.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
+cd "$(dirname "$0")"
 
-SCRIPT_MODE=$1
+SCRIPT_MODE=${1:-0}
 
 source ~/.bashrc
 # Ensures foundry is installed and up to date with foundry.lock
@@ -9,7 +10,7 @@ source ~/.bashrc
 
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install -r requirements.txt
+python3 -m pip install --quiet -r requirements.txt
 
 if [ $SCRIPT_MODE = "--with-build" ]; then
 	forge build

--- a/script/ParseProtocolDeploy.sh
+++ b/script/ParseProtocolDeploy.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
 ENV_FILE=".env"
 
-if [[ -n $CHAIN_ID ]]; then
-  CHAIN_ID=${CHAIN_ID}
-elif [[ -n $DB_CHAIN ]]; then
-  CHAIN_ID=${DB_CHAIN}
-else
-  CHAIN_ID=31337
-fi
+# Fallback to DB_CHAIN or 31337 if neither are set
+CHAIN_ID=${CHAIN_ID:-${DB_CHAIN:-31337}}
 
 settingChainID=false
 


### PR DESCRIPTION
Each deploy script used to run `foundryup`, so composite scripts like install-deploy-check caused Foundry to compile 3 times! This refactor will greatly speed developer usage and reduce GHA spend.