### PR TITLE
2/3: Refactor install-deploy-check

### DIFF
--- a/.github/PRChecklist.md
+++ b/.github/PRChecklist.md
@@ -32,7 +32,7 @@
 
    1. Make sure `foundry.lock` is set to an appropriate version, then update Foundry.
 
-      `foundryup --commit $(awk '$1~/^[^#]/' foundry.lock)`
+      `./foundry-version-check.sh`
 
    2. Generate the docs:
 

--- a/deployAppERC20Test.sh
+++ b/deployAppERC20Test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployAppERC20Test.sh
+++ b/deployAppERC20Test.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -17,14 +15,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
-# make sure that foundry is installed. If it is, update it to the specific version. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+
+./foundry-version-check.sh
 
 if [ -n $FOUNDRY_PROFILE ]; then
   RPC_URL="local"

--- a/deployAppERC721Test.sh
+++ b/deployAppERC721Test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployAppERC721Test.sh
+++ b/deployAppERC721Test.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -18,14 +16,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# make sure that foundry is installed. If it is, update it. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+./foundry-version-check.sh
 
 if [ -n $FOUNDRY_PROFILE ]; then
   RPC_URL="local"

--- a/deployAppManagerTest.sh
+++ b/deployAppManagerTest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployAppManagerTest.sh
+++ b/deployAppManagerTest.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -18,14 +16,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# make sure that foundry is installed. If it is, update it. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+./foundry-version-check.sh
 
 ##### VALIDATE and RETRIEVE Entry variables
 

--- a/deployProtocolTest.sh
+++ b/deployProtocolTest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 cd "$(dirname "$0")"
 
 # function to get input from the user

--- a/deployProtocolTest.sh
+++ b/deployProtocolTest.sh
@@ -1,9 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
 
-# function to check for installations
-installed()
-{
-  command -v "$1" >/dev/null 2>&1
-}
 # function to get input from the user
 promptForInput() {
   echo -n "Enter $1: "
@@ -18,14 +16,7 @@ GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# make sure that foundry is installed. If it is, update it. If not, install it.
-if installed forge; then
-  echo "...Updating Foundry..."
-  COMMAND="$(foundryup --commit $(awk '$1~/^[^#]/' foundry.lock))"
-else
-  echo "...Installing Foundry..."
-  $(curl -L https://foundry.paradigm.xyz)
-fi
+./foundry-version-check.sh
 
 ##### VALIDATE and RETRIEVE Entry variables
 

--- a/foundry-version-check.sh
+++ b/foundry-version-check.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+foundry_pinned_version=$(awk '!/^#/ {print $0; exit}' foundry.lock)
+# `forge --version` refers to the first 8 characters of the commit hash
+foundry_version_short=${foundry_pinned_version:0:8}
+skip_install=${SKIP_INSTALL:-false}
+flags=${1:-0}
+
+if [ $flags = "--skip-install" ]; then
+  skip_install=true
+fi
+
+function installed() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+function installed_current() {
+  command "$1" --version | grep "$foundry_version_short" >/dev/null 2>&1
+}
+
+if installed_current forge && installed_current anvil && installed_current cast; then
+  echo "✅ Foundry, Anvil, and Cast are already installed and up to date."
+  exit 0
+elif installed forge && installed anvil && installed cast; then
+  echo "🦖 Foundry is out of date."
+  if $skip_install; then
+    echo "--skip-install used. Skipping installation..."
+  else
+    echo "🚀 Updating Foundry..."
+    foundryup --commit $foundry_pinned_version
+  fi
+else
+  echo "❌ Foundry is not installed."
+  if $skip_install; then
+    echo "--skip-install used. Skipping installation..."
+  else
+    echo "🏗️ Installing Foundry..."
+    $(curl -L https://foundry.paradigm.xyz)
+  fi
+fi

--- a/foundry-version-check.sh
+++ b/foundry-version-check.sh
@@ -38,5 +38,6 @@ else
   else
     echo "🏗️ Installing Foundry..."
     $(curl -L https://foundry.paradigm.xyz)
+    foundryup --commit $foundry_pinned_version
   fi
 fi

--- a/install-deploy-check.sh
+++ b/install-deploy-check.sh
@@ -33,33 +33,33 @@ fi
 
 if [ $SCRIPT_MODE = "--with-deploy-check" ]; then
   echo "Running Deployments to Anvil... Only errors will be displayed."
-  # {
-  #   source script/SetupProtocolDeploy.sh
-  #   forge script script/DeployAllModulesPt1.s.sol --ffi --broadcast
-  #   source script/ParseProtocolDeploy.sh
-  #   forge script script/DeployAllModulesPt2.s.sol --ffi --broadcast
-  #   forge script script/DeployAllModulesPt3.s.sol --ffi --broadcast
-  #   forge script script/DeployAllModulesPt4.s.sol --ffi --broadcast
+  {
+    source script/SetupProtocolDeploy.sh
+    forge script script/DeployAllModulesPt1.s.sol --ffi --broadcast
+    source script/ParseProtocolDeploy.sh
+    forge script script/DeployAllModulesPt2.s.sol --ffi --broadcast
+    forge script script/DeployAllModulesPt3.s.sol --ffi --broadcast
+    forge script script/DeployAllModulesPt4.s.sol --ffi --broadcast
 
-  #   forge script script/clientScripts/Application_Deploy_01_AppManager.s.sol --ffi --broadcast
-  #   source script/ParseApplicationDeploy.sh 1
-  #   forge script script/clientScripts/Application_Deploy_02_ApplicationFT1.s.sol --ffi --broadcast 
-  #   source script/ParseApplicationDeploy.sh 2
-  #   forge script script/clientScripts/Application_Deploy_02_ApplicationFT1Pt2.s.sol --ffi --broadcast 
-  #   forge script script/clientScripts/Application_Deploy_04_ApplicationNFT.s.sol --ffi --broadcast
-  #   source script/ParseApplicationDeploy.sh 3
-  #   forge script script/clientScripts/Application_Deploy_04_ApplicationNFTPt2.s.sol --ffi --broadcast 
-  #   forge script script/clientScripts/Application_Deploy_05_Oracle.s.sol --ffi --broadcast 
-  #   source script/ParseApplicationDeploy.sh 4
-  #   forge script script/clientScripts/Application_Deploy_06_Pricing.s.sol --ffi --broadcast
-  #   source script/ParseApplicationDeploy.sh 5
-  #   forge script script/clientScripts/Application_Deploy_07_ApplicationAdminRoles.s.sol --ffi --broadcast
-  # } > /dev/null # silence stdout (error output will be shown)
+    forge script script/clientScripts/Application_Deploy_01_AppManager.s.sol --ffi --broadcast
+    source script/ParseApplicationDeploy.sh 1
+    forge script script/clientScripts/Application_Deploy_02_ApplicationFT1.s.sol --ffi --broadcast 
+    source script/ParseApplicationDeploy.sh 2
+    forge script script/clientScripts/Application_Deploy_02_ApplicationFT1Pt2.s.sol --ffi --broadcast 
+    forge script script/clientScripts/Application_Deploy_04_ApplicationNFT.s.sol --ffi --broadcast
+    source script/ParseApplicationDeploy.sh 3
+    forge script script/clientScripts/Application_Deploy_04_ApplicationNFTPt2.s.sol --ffi --broadcast 
+    forge script script/clientScripts/Application_Deploy_05_Oracle.s.sol --ffi --broadcast 
+    source script/ParseApplicationDeploy.sh 4
+    forge script script/clientScripts/Application_Deploy_06_Pricing.s.sol --ffi --broadcast
+    source script/ParseApplicationDeploy.sh 5
+    forge script script/clientScripts/Application_Deploy_07_ApplicationAdminRoles.s.sol --ffi --broadcast
+  } > /dev/null # silence stdout (error output will be shown)
 
   test_commands=(
-    # "forge test --ffi -vv --match-contract RuleProcessorDiamondTest"
-    # "forge test --ffi -vv --match-contract ApplicationDeploymentTest"
-    # "bash deployAppERC20Test.sh"
+    "forge test --ffi -vv --match-contract RuleProcessorDiamondTest"
+    "forge test --ffi -vv --match-contract ApplicationDeploymentTest"
+    "bash deployAppERC20Test.sh"
     "bash deployAppERC721Test.sh"
     "node abi-aggregator.mjs --branch \"$GITHUB_BRANCH_NAME\""
   )

--- a/install-deploy-check.sh
+++ b/install-deploy-check.sh
@@ -1,64 +1,93 @@
 #!/bin/bash
+set +e # Proceed on errors
+cd "$(dirname "$0")"
 
-SCRIPT_MODE=$1
+GITHUB_BRANCH_NAME=${GITHUB_BRANCH_NAME:-HEAD}
+SNS_TOPIC_ARN="arn:aws:sns:us-east-1:560711875040:GHDeployTest"
+
+SCRIPT_MODE=${1:-0}
+# Ensures foundry is installed and up to date with foundry.lock
+./foundry-version-check.sh
 
 source ~/.bashrc
-# Pin foundry to a known-good commit hash. Awk ignores comments in `foundry.lock`
-foundryup --commit $(awk '$1~/^[^#]/' foundry.lock)
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install -r requirements.txt
+python3 -m pip install --quiet -r requirements.txt
+
+case $SCRIPT_MODE in
+  "--with-build")
+    echo "Building..."
+    ;;
+  "--with-deploy-check")
+    echo "Deploying..."
+    ;;
+  *)
+    echo "No script mode specified. Provide --with-build or --with-deploy-check. Exiting..."
+    exit 1
+    ;;
+esac
 
 if [ $SCRIPT_MODE = "--with-build" ]; then
-  forge build   
+  forge build
 fi
 
 if [ $SCRIPT_MODE = "--with-deploy-check" ]; then
-  source script/SetupProtocolDeploy.sh
-  forge script script/DeployAllModulesPt1.s.sol --ffi --broadcast
-  source script/ParseProtocolDeploy.sh
-  forge script script/DeployAllModulesPt2.s.sol --ffi --broadcast
-  forge script script/DeployAllModulesPt3.s.sol --ffi --broadcast
-  forge script script/DeployAllModulesPt4.s.sol --ffi --broadcast
+  echo "Running Deployments to Anvil... Only errors will be displayed."
+  # {
+  #   source script/SetupProtocolDeploy.sh
+  #   forge script script/DeployAllModulesPt1.s.sol --ffi --broadcast
+  #   source script/ParseProtocolDeploy.sh
+  #   forge script script/DeployAllModulesPt2.s.sol --ffi --broadcast
+  #   forge script script/DeployAllModulesPt3.s.sol --ffi --broadcast
+  #   forge script script/DeployAllModulesPt4.s.sol --ffi --broadcast
 
-  forge script script/clientScripts/Application_Deploy_01_AppManager.s.sol --ffi --broadcast
-  source script/ParseApplicationDeploy.sh 1
-  forge script script/clientScripts/Application_Deploy_02_ApplicationFT1.s.sol --ffi --broadcast 
-  source script/ParseApplicationDeploy.sh 2
-  forge script script/clientScripts/Application_Deploy_02_ApplicationFT1Pt2.s.sol --ffi --broadcast 
-  forge script script/clientScripts/Application_Deploy_04_ApplicationNFT.s.sol --ffi --broadcast
-  source script/ParseApplicationDeploy.sh 3
-  forge script script/clientScripts/Application_Deploy_04_ApplicationNFTPt2.s.sol --ffi --broadcast 
-  forge script script/clientScripts/Application_Deploy_05_Oracle.s.sol --ffi --broadcast 
-  source script/ParseApplicationDeploy.sh 4
-  forge script script/clientScripts/Application_Deploy_06_Pricing.s.sol --ffi --broadcast
-  source script/ParseApplicationDeploy.sh 5
-  forge script script/clientScripts/Application_Deploy_07_ApplicationAdminRoles.s.sol --ffi --broadcast
+  #   forge script script/clientScripts/Application_Deploy_01_AppManager.s.sol --ffi --broadcast
+  #   source script/ParseApplicationDeploy.sh 1
+  #   forge script script/clientScripts/Application_Deploy_02_ApplicationFT1.s.sol --ffi --broadcast 
+  #   source script/ParseApplicationDeploy.sh 2
+  #   forge script script/clientScripts/Application_Deploy_02_ApplicationFT1Pt2.s.sol --ffi --broadcast 
+  #   forge script script/clientScripts/Application_Deploy_04_ApplicationNFT.s.sol --ffi --broadcast
+  #   source script/ParseApplicationDeploy.sh 3
+  #   forge script script/clientScripts/Application_Deploy_04_ApplicationNFTPt2.s.sol --ffi --broadcast 
+  #   forge script script/clientScripts/Application_Deploy_05_Oracle.s.sol --ffi --broadcast 
+  #   source script/ParseApplicationDeploy.sh 4
+  #   forge script script/clientScripts/Application_Deploy_06_Pricing.s.sol --ffi --broadcast
+  #   source script/ParseApplicationDeploy.sh 5
+  #   forge script script/clientScripts/Application_Deploy_07_ApplicationAdminRoles.s.sol --ffi --broadcast
+  # } > /dev/null # silence stdout (error output will be shown)
 
-  TEST_ONE_UNCUT=$(forge test --ffi -vv --match-contract RuleProcessorDiamondTest)
-  TEST_ONE=$(echo $TEST_ONE_UNCUT | tail -n 1 | grep "0m failed" | wc -l | tr -d ' ')
-  TEST_TWO_UNCUT=$(forge test --ffi -vv --match-contract ApplicationDeploymentTest)
-  TEST_TWO=$(echo $TEST_TWO_UNCUT | tail -n 1 | grep "0m failed" | wc -l | tr -d ' ')
-  TEST_THREE_UNCUT=$(bash deployAppERC20Test.sh)
-  TEST_THREE=$(echo TEST_THREE_UNCUT | tail -n 1 | grep "FAIL" | wc -l | tr -d ' ')
-  TEST_FOUR_UNCUT=$(bash deployAppERC721Test.sh)
-  TEST_FOUR=$(echo TEST_FOUR_UNCUT | tail -n 1 | grep "FAIL" | wc -l | tr -d ' ')
+  test_commands=(
+    # "forge test --ffi -vv --match-contract RuleProcessorDiamondTest"
+    # "forge test --ffi -vv --match-contract ApplicationDeploymentTest"
+    # "bash deployAppERC20Test.sh"
+    "bash deployAppERC721Test.sh"
+    "node abi-aggregator.mjs --branch \"$GITHUB_BRANCH_NAME\""
+  )
 
-  TEST_FIVE_UNCUT=$(node abi-aggregator.mjs --branch $GITHUB_BRANCH_NAME)
-  TEST_FIVE=$?
+  echo "Running tests..."
+  NUM_FAILED=0
+  for command in "${test_commands[@]}"; do
+      # Run command in a subshell and capture stderr
+      output=$( { eval "$command"; } 2>&1 )
+      # Capture return value
+      retval=$?
 
-  echo $TEST_ONE_UNCUT
-  echo $TEST_TWO_UNCUT
-  echo $TEST_THREE_UNCUT
-  echo $TEST_FOUR_UNCUT
-  echo $TEST_FIVE_UNCUT
+      # If return value is non-zero, the test failed
+      if [ $retval -ne 0 ]; then
+        echo " ❌ '$command' failed. Errors were:\n" >&2
+        echo -e "=================================" >&2
+        echo -e "$output"
+        echo -e "=================================\n" >&2
+        NUM_FAILED=$((NUM_FAILED+1))
+      fi
+  done
 
-  if [ "1" = "$TEST_ONE" ] && [ "1" = "$TEST_TWO" ] && [ "0" == "$TEST_THREE" ] && [ "0" == "$TEST_FOUR" ] && [ "0" == "$TEST_FIVE" ]; then
-    echo "Running K8s Build And Deploy workflow for $GITHUB_BRANCH_NAME"
-    export GH_TOKEN=$(aws secretsmanager get-secret-value --secret-id arn:aws:secretsmanager:us-east-1:560711875040:secret:GHPAT-y6CS5m --region us-east-1 | jq -r '.SecretString' | jq -r .GHPAT)
-    gh workflow run k8s.yml --ref $GITHUB_BRANCH_NAME
-  else 
-    echo "Sending sns message for failure"
-    aws sns publish --topic-arn arn:aws:sns:us-east-1:560711875040:GHDeployTest --message "Deploy Test failed for branch $GITHUB_BRANCH_NAME"
+  if [ $NUM_FAILED -gt 0 ]; then
+    echo "❌ $NUM_FAILED tests failed. Sending SNS message..."
+    aws sns publish --topic-arn $SNS_TOPIC_ARN --message "Deploy Test failed for branch $GITHUB_BRANCH_NAME"
+    exit 1
+  else
+    echo "✅ All tests passed."
+    echo -e "\n\n!!! TODO in PR 3/3 !!!: GitHub Actions 'Deploy' workflow will run this in a step. This script will no longer invoke a deployment."
   fi
 fi

--- a/install-forge.sh
+++ b/install-forge.sh
@@ -4,8 +4,9 @@ set -e
 SCRIPT_MODE=$1
 
 source ~/.bashrc
-# Pin foundry to a known-good commit hash. Awk ignores comments in `foundry.lock`
-foundryup --commit $(awk '$1~/^[^#]/' foundry.lock)
+# Ensures foundry is installed and up to date with foundry.lock
+./foundry-version-check.sh
+
 python3 -m venv .venv
 source .venv/bin/activate
 python3 -m pip install -r requirements.txt

--- a/install-forge.sh
+++ b/install-forge.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
+cd "$(dirname "$0")"
 
-SCRIPT_MODE=$1
+SCRIPT_MODE=${1:-0}
 
 source ~/.bashrc
 # Ensures foundry is installed and up to date with foundry.lock
@@ -9,7 +10,7 @@ source ~/.bashrc
 
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install -r requirements.txt
+python3 -m pip install --quiet -r requirements.txt
 
 if [ $SCRIPT_MODE = "--with-build" ]; then
 	forge build

--- a/script/ParseProtocolDeploy.sh
+++ b/script/ParseProtocolDeploy.sh
@@ -1,14 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
 ENV_FILE=".env"
 
-if [[ -n $CHAIN_ID ]]; then
-  CHAIN_ID=${CHAIN_ID}
-elif [[ -n $DB_CHAIN ]]; then
-  CHAIN_ID=${DB_CHAIN}
-else
-  CHAIN_ID=31337
-fi
+# Fallback to DB_CHAIN or 31337 if neither are set
+CHAIN_ID=${CHAIN_ID:-${DB_CHAIN:-31337}}
 
 settingChainID=false
 


### PR DESCRIPTION
PR Note: Once #382 is merged, change this PR's base to `main`.

## Refactor of `install-deploy-check`

- Capture stdout and stderr in `[install-deploy-check.sh](http://install-deploy-check.sh/)`, only print anything on failures. (Successes should be silent)

- Use standardized exit codes (0: success, -1: failure)

- Separate it from Universus K8s deployment steps. That workflow can run this as a pre-step.