### PR TITLE
SE-748-Change-Atomic-Rule-Set-functions-in-token-handlers-to-accept-ActionTypes-Array-length-of-0

### DIFF
--- a/src/client/token/handler/ruleContracts/HandlerAccountApproveDenyOracle.sol
+++ b/src/client/token/handler/ruleContracts/HandlerAccountApproveDenyOracle.sol
@@ -37,7 +37,6 @@ contract HandlerAccountApproveDenyOracle is RuleAdministratorOnly, ActionTypesAr
      * @param _ruleIds Rule Id corresponding to the actions
      */
     function setAccountApproveDenyOracleIdFull(ActionTypes[] calldata _actions, uint32[] calldata _ruleIds) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _ruleIds.length) revert InputArraysMustHaveSameLength();
         clearAccountApproveDenyOracle();
         for (uint i; i < _actions.length; ++i) {

--- a/src/client/token/handler/ruleContracts/HandlerAccountApproveDenyOracle.sol
+++ b/src/client/token/handler/ruleContracts/HandlerAccountApproveDenyOracle.sol
@@ -33,6 +33,7 @@ contract HandlerAccountApproveDenyOracle is RuleAdministratorOnly, ActionTypesAr
     /**
      * @dev Set the AccountApproveDenyOracle suite. This function works differently since the rule allows multiples per action. The actions are repeated to account for multiple oracle rules per action. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _ruleIds Rule Id corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerAccountMaxTradeSize.sol
+++ b/src/client/token/handler/ruleContracts/HandlerAccountMaxTradeSize.sol
@@ -39,6 +39,7 @@ contract HandlerAccountMaxTradeSize is RuleAdministratorOnly, ActionTypesArray, 
     /**
      * @dev Set the AccountMaxTradeSizeRule suite. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _ruleIds Rule Id corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerAccountMaxTradeSize.sol
+++ b/src/client/token/handler/ruleContracts/HandlerAccountMaxTradeSize.sol
@@ -43,7 +43,6 @@ contract HandlerAccountMaxTradeSize is RuleAdministratorOnly, ActionTypesArray, 
      * @param _ruleIds Rule Id corresponding to the actions
      */
     function setAccountMaxTradeSizeIdFull(ActionTypes[] calldata _actions, uint32[] calldata _ruleIds) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _ruleIds.length) revert InputArraysMustHaveSameLength();
         clearAccountMaxTradeSize();
         for (uint i; i < _actions.length; ++i) {

--- a/src/client/token/handler/ruleContracts/HandlerAccountMinMaxTokenBalance.sol
+++ b/src/client/token/handler/ruleContracts/HandlerAccountMinMaxTokenBalance.sol
@@ -30,6 +30,7 @@ contract HandlerAccountMinMaxTokenBalance is RuleAdministratorOnly, ActionTypesA
     /**
      * @dev Set the setAccountMinMaxTokenBalanceRule suite. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _ruleIds Rule Id corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerAccountMinMaxTokenBalance.sol
+++ b/src/client/token/handler/ruleContracts/HandlerAccountMinMaxTokenBalance.sol
@@ -34,7 +34,6 @@ contract HandlerAccountMinMaxTokenBalance is RuleAdministratorOnly, ActionTypesA
      * @param _ruleIds Rule Id corresponding to the actions
      */
     function setAccountMinMaxTokenBalanceIdFull(ActionTypes[] calldata _actions, uint32[] calldata _ruleIds) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _ruleIds.length) revert InputArraysMustHaveSameLength();
         clearMinMaxTokenBalance();
         for (uint i; i < _actions.length; ++i) {

--- a/src/client/token/handler/ruleContracts/HandlerTokenMaxBuySellVolume.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMaxBuySellVolume.sol
@@ -39,6 +39,7 @@ contract HandlerTokenMaxBuySellVolume is RuleAdministratorOnly, ActionTypesArray
     /**
      * @dev Set the TokenMaxBuySellVolume suite. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _ruleIds Rule Id corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerTokenMaxBuySellVolume.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMaxBuySellVolume.sol
@@ -43,7 +43,6 @@ contract HandlerTokenMaxBuySellVolume is RuleAdministratorOnly, ActionTypesArray
      * @param _ruleIds Rule Id corresponding to the actions
      */
     function setTokenMaxBuySellVolumeIdFull(ActionTypes[] calldata _actions, uint32[] calldata _ruleIds) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _ruleIds.length) revert InputArraysMustHaveSameLength();
         clearTokenMaxBuySellVolume();
         for (uint i; i < _actions.length; ++i) {

--- a/src/client/token/handler/ruleContracts/HandlerTokenMaxDailyTrades.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMaxDailyTrades.sol
@@ -31,6 +31,7 @@ contract HandlerTokenMaxDailyTrades is RuleAdministratorOnly, ActionTypesArray, 
     /**
      * @dev Set the setTokenMaxDailyTrades Rule suite. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _ruleIds Rule Id corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerTokenMaxDailyTrades.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMaxDailyTrades.sol
@@ -35,7 +35,6 @@ contract HandlerTokenMaxDailyTrades is RuleAdministratorOnly, ActionTypesArray, 
      * @param _ruleIds Rule Id corresponding to the actions
      */
     function setTokenMaxDailyTradesIdFull(ActionTypes[] calldata _actions, uint32[] calldata _ruleIds) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _ruleIds.length) revert InputArraysMustHaveSameLength();
         clearTokenMaxDailyTrades();
         for (uint i; i < _actions.length; ++i) {

--- a/src/client/token/handler/ruleContracts/HandlerTokenMinHoldTime.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMinHoldTime.sol
@@ -47,6 +47,7 @@ contract HandlerTokenMinHoldTime is RuleAdministratorOnly, ITokenHandlerEvents, 
     /**
      * @dev Set the setTokenMinHoldTimeRule suite. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _minHoldTimeHours min hold time in hours corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerTokenMinHoldTime.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMinHoldTime.sol
@@ -51,7 +51,6 @@ contract HandlerTokenMinHoldTime is RuleAdministratorOnly, ITokenHandlerEvents, 
      * @param _minHoldTimeHours min hold time in hours corresponding to the actions
      */
     function setTokenMinHoldTimeFull(ActionTypes[] calldata _actions, uint32[] calldata _minHoldTimeHours) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _minHoldTimeHours.length) revert InputArraysMustHaveSameLength();
         clearTokenMinHoldTime();
         for (uint i; i < _actions.length; ++i) {

--- a/src/client/token/handler/ruleContracts/HandlerTokenMinTxSize.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMinTxSize.sol
@@ -31,6 +31,7 @@ contract HandlerTokenMinTxSize is RuleAdministratorOnly, ActionTypesArray, IToke
     /**
      * @dev Set the setTokenMinTxSizeRule suite. Restricted to rule administrators only.
      * @notice that setting a rule will automatically activate it.
+     * @notice This function does not check that the array length is greater than zero to allow for clearing out of the action types data
      * @param _actions actions to have the rule applied to
      * @param _ruleIds Rule Id corresponding to the actions
      */

--- a/src/client/token/handler/ruleContracts/HandlerTokenMinTxSize.sol
+++ b/src/client/token/handler/ruleContracts/HandlerTokenMinTxSize.sol
@@ -35,7 +35,6 @@ contract HandlerTokenMinTxSize is RuleAdministratorOnly, ActionTypesArray, IToke
      * @param _ruleIds Rule Id corresponding to the actions
      */
     function setTokenMinTxSizeIdFull(ActionTypes[] calldata _actions, uint32[] calldata _ruleIds) external ruleAdministratorOnly(lib.handlerBaseStorage().appManager) {
-        if (_actions.length == 0) revert InputArraysSizesNotValid();
         if (_actions.length != _ruleIds.length) revert InputArraysMustHaveSameLength();
         clearTokenMinTxSize();
         for (uint i; i < _actions.length; ++i) {

--- a/test/client/token/ERC20/integration/ERC20CommonTests.t.sol
+++ b/test/client/token/ERC20/integration/ERC20CommonTests.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "test/util/TestCommonFoundry.sol";
 import "../../TestTokenCommon.sol";
 import "test/client/token/ERC20/util/ERC20Util.sol";
+import "src/client/token/handler/ruleContracts/HandlerAccountMinMaxTokenBalance.sol";
 
 abstract contract ERC20CommonTests is TestCommonFoundry, DummyAMM, ERC20Util {
     IERC20 testCaseToken;
@@ -1732,6 +1733,37 @@ abstract contract ERC20CommonTests is TestCommonFoundry, DummyAMM, ERC20Util {
         assertFalse(ERC20TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(ActionTypes.BURN));
     }
 
+    function testERC20_ERC20CommonTests_AccountMinMaxTokenBalanceAtomicFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](5);
+        bytes32[5] memory tags = [bytes32("Shane"), bytes32("RJ"), bytes32("Tayler"), bytes32("Michael"), bytes32("Gordon")];
+        for (uint i; i < ruleIds.length; i++) createAccountMinMaxTokenBalanceRule(createBytes32Array(tags[i]), createUint256Array(i + 1), createUint256Array((i + 1) * 1000));
+        
+        // Set up rules
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.P2P_TRANSFER, ActionTypes.SELL, ActionTypes.BUY, ActionTypes.MINT, ActionTypes.BURN);
+        
+        // Apply the rules to all actions
+        setAccountMinMaxTokenBalanceRuleFull(address(applicationCoinHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly and actions activated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(ERC20TaggedRuleFacet(address(applicationCoinHandler)).getAccountMinMaxTokenBalanceId(actions[i]), ruleIds[i]);
+            assertTrue(ERC20TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(actions[i]));
+        }
+        
+        // Create zero length arrays
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+        uint32[] memory ruleIdsZero = new uint32[](0);
+
+        // Clear the rule data with zero length actions array
+        setAccountMinMaxTokenBalanceRuleFull(address(applicationCoinHandler), actionsZero, ruleIdsZero);
+
+        // Verify that the old rules were cleared correctly and actions deactivated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(ERC20TaggedRuleFacet(address(applicationCoinHandler)).getAccountMinMaxTokenBalanceId(actions[i]), 0);
+            assertFalse(ERC20TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(actions[i]));
+        }
+    }
+
     /* AccountMaxTradeSize */
     function testERC20_ERC20CommonTests_AccountMaxTradeSizeAtomicFullSetSell() public {
         uint32[] memory ruleIds = new uint32[](1);
@@ -1789,6 +1821,36 @@ abstract contract ERC20CommonTests is TestCommonFoundry, DummyAMM, ERC20Util {
         assertTrue(TradingRuleFacet(address(applicationCoinHandler)).isAccountMaxTradeSizeActive(ActionTypes.SELL));
     }
 
+    function testERC20_ERC20CommonTests_AccountMaxTradeSizeAtomicFull_ZeroLengthActions() public {
+        // Create rules
+        uint32[] memory ruleIds = new uint32[](2);
+        ruleIds[0] = createAccountMaxTradeSizeRule("Gordon", 100, 5);
+        ruleIds[1] = createAccountMaxTradeSizeRule("Tayler", 200, 5);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.SELL, ActionTypes.BUY);
+
+        // Apply rules
+        setAccountMaxTradeSizeIdFull(address(applicationCoinHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly and actions activated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(TradingRuleFacet(address(applicationCoinHandler)).getAccountMaxTradeSizeId(actions[i]), ruleIds[i]);
+            assertTrue(TradingRuleFacet(address(applicationCoinHandler)).isAccountMaxTradeSizeActive(actions[i]));
+        }
+
+        // Create zero length arrays
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+        uint32[] memory ruleIdsZero = new uint32[](0);
+
+        // Apply new zero length rules
+        setAccountMaxTradeSizeIdFull(address(applicationCoinHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule id's were cleared correctly and actions deactivated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(TradingRuleFacet(address(applicationCoinHandler)).getAccountMaxTradeSizeId(actions[i]), 0);
+            assertFalse(TradingRuleFacet(address(applicationCoinHandler)).isAccountMaxTradeSizeActive(actions[i]));
+        }
+    }
+
     function testERC20_ERC20CommonTests_TokenMaxBuySellVolumeBuyActionAtomicFullReSet() public {
         uint32 ruleId = createTokenMaxBuySellVolumeRule(10, 24, 0, Blocktime);
         ActionTypes[] memory actions = createActionTypeArray(ActionTypes.BUY);
@@ -1814,6 +1876,36 @@ abstract contract ERC20CommonTests is TestCommonFoundry, DummyAMM, ERC20Util {
         assertEq(TradingRuleFacet(address(applicationCoinHandler)).getTokenMaxBuySellVolumeId(ActionTypes.BUY), ruleId);
         // Verify that all the rules were activated
         assertTrue(TradingRuleFacet(address(applicationCoinHandler)).isTokenMaxBuySellVolumeActive(ActionTypes.BUY));
+    }
+
+    function testERC20_ERC20CommonTests_TokenMaxBuySellVolumeAtomicFull_ZeroLengthActions() public {
+        // Create rules
+        uint32[] memory ruleIds = new uint32[](2);
+        ruleIds[0] = createTokenMaxBuySellVolumeRule(10, 48, 0, Blocktime);
+        ruleIds[1] = createTokenMaxBuySellVolumeRule(20, 68, 0, Blocktime);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.BUY, ActionTypes.SELL);
+
+        // Apply rules
+        setTokenMaxBuySellVolumeIdFull(address(applicationCoinHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly and actions activated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(TradingRuleFacet(address(applicationCoinHandler)).getTokenMaxBuySellVolumeId(actions[i]), ruleIds[i]);
+            assertTrue(TradingRuleFacet(address(applicationCoinHandler)).isTokenMaxBuySellVolumeActive(actions[i]));
+        }
+
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply new zero length rules
+        setTokenMaxBuySellVolumeIdFull(address(applicationCoinHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule id's were cleared correctly and actions deactivated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(TradingRuleFacet(address(applicationCoinHandler)).getTokenMaxBuySellVolumeId(actions[i]), 0);
+            assertFalse(TradingRuleFacet(address(applicationCoinHandler)).isTokenMaxBuySellVolumeActive(actions[i]));
+        }
     }
 
     function testERC20_ERC20CommonTests_TokenMaxBuySellVolumeAtomicFullReSet() public {
@@ -1937,6 +2029,44 @@ abstract contract ERC20CommonTests is TestCommonFoundry, DummyAMM, ERC20Util {
         }
     }
 
+    function testERC20_ERC20CommonTests_AccountApproveDenyOracleAtomicFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](25);
+        ActionTypes[] memory actions = new ActionTypes[](25);
+
+        // Set up rules
+        uint256 actionIndex;
+        uint256 mainIndex;
+        for (uint i; i < 5; i++) {
+            for (uint j; j < 5; j++) {
+                actions[mainIndex] = ActionTypes(actionIndex);
+                ruleIds[mainIndex] = createAccountApproveDenyOracleRule(0);
+                mainIndex++;
+            }
+            actionIndex++;
+        }
+
+        // Apply the rules to all actions
+        setAccountApproveDenyOracleRuleFull(address(applicationNFTHandler), actions, ruleIds);
+        
+        // Verify that all the rule id's were set correctly and are active
+        for (uint i; i < 5; i++) {
+            assertEq(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).getAccountApproveDenyOracleIds(actions[i])[i], ruleIds[i]);
+            assertTrue(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isAccountApproveDenyOracleActive(actions[i], ruleIds[i]));
+        }
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply zero length arrays
+        setAccountApproveDenyOracleRuleFull(address(applicationNFTHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule ids were cleared and not active
+        for (uint i; i < 5; i++) {
+            assertEq(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).getAccountApproveDenyOracleIds(actions[i]).length, 0);
+            assertFalse(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isAccountApproveDenyOracleActive(actions[i], ruleIds[i]));
+        }
+    }
+
     /* TokenMinimumTransaction */
     function testERC20_ERC20CommonTests_TokenMinimumTransactionAtomicFullSet() public {
         uint32[] memory ruleIds = new uint32[](5);
@@ -1983,6 +2113,35 @@ abstract contract ERC20CommonTests is TestCommonFoundry, DummyAMM, ERC20Util {
         assertFalse(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinTxSizeActive(ActionTypes.P2P_TRANSFER));
         assertFalse(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinTxSizeActive(ActionTypes.MINT));
         assertFalse(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinTxSizeActive(ActionTypes.BURN));
+    }
+
+    function testERC20_ERC20CommonTests_TokenMinimumTransactionAtomicFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](5);
+        // Set up rules
+        for (uint i; i < 5; i++) ruleIds[i] = createTokenMinimumTransactionRule(i + 1);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.P2P_TRANSFER, ActionTypes.SELL, ActionTypes.BUY, ActionTypes.MINT, ActionTypes.BURN);
+
+        // Apply the rules to all actions
+        setTokenMinimumTransactionRuleFull(address(applicationNFTHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly and actions activated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).getTokenMinTxSizeId(actions[i]), ruleIds[i]);
+            assertTrue(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinTxSizeActive(actions[i]));
+        }
+        
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply the new zero length rules
+        setTokenMinimumTransactionRuleFull(address(applicationNFTHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule id's were cleared correctly and actions deacivated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).getTokenMinTxSizeId(actions[i]), 0);
+            assertFalse(ERC20NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinTxSizeActive(actions[i]));
+        }
     }
 
     /// Utility Helper Functions

--- a/test/client/token/ERC20/util/ERC20Util.sol
+++ b/test/client/token/ERC20/util/ERC20Util.sol
@@ -64,6 +64,16 @@ abstract contract ERC20Util is TokenUtils, DummyAMM {
         ERC20NonTaggedRuleFacet(address(assetHandler)).setTokenMaxTradingVolumeId(actionTypes, ruleId);
     }
 
+    function setAccountMaxTradeSizeIdFull(address assetHandler, ActionTypes[] memory actions, uint32[] memory ruleIds) public endWithStopPrank {
+        switchToRuleAdmin();
+        TradingRuleFacet(address(assetHandler)).setAccountMaxTradeSizeIdFull(actions, ruleIds);
+    }
+
+    function setTokenMaxBuySellVolumeIdFull(address assetHandler, ActionTypes[] memory actions, uint32[] memory ruleIds) public endWithStopPrank {
+        switchToRuleAdmin();
+        TradingRuleFacet(address(assetHandler)).setTokenMaxBuySellVolumeIdFull(actions, ruleIds);
+    }
+
     function setTokenMaxTradingVolumeRuleSingleAction(ActionTypes _action, address assetHandler, uint32 ruleId) public endWithStopPrank {
         switchToRuleAdmin();
         ActionTypes[] memory actionTypes = createActionTypeArray(_action);

--- a/test/client/token/ERC721/integration/ERC721CommonTests.t.sol
+++ b/test/client/token/ERC721/integration/ERC721CommonTests.t.sol
@@ -400,7 +400,6 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         amm.dummyTrade(address(applicationCoin), address(testCaseNFT), 0, 12, false);
     }
 
-
     function testERC721_ERC721CommonTests_PauseRulesViaAppManager() public endWithStopPrank {
         switchToAppAdministrator();
         /// set up a non admin user an nft
@@ -1804,6 +1803,36 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         _testBuyNFT(1, amm);
     }
 
+    function testERC721_ERC721CommonTests_AccountMaxTradeSizeAtomicFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](2);
+        // Set up rules
+        ruleIds[1] = createAccountMaxTradeSizeRule("MaxSellSize", 1, 24);
+        ruleIds[0] = createAccountMaxTradeSizeRule("MaxBuySize", 1, 24);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.SELL, ActionTypes.BUY);
+
+        // Apply the rules to all actions
+        setAccountMaxTradeSizeRuleFull(address(applicationNFTHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly
+        for (uint i; i < ruleIds.length; i++) {
+            assertEq(TradingRuleFacet(address(applicationNFTHandler)).getAccountMaxTradeSizeId(actions[i]), ruleIds[i]);
+            assertTrue(TradingRuleFacet(address(applicationNFTHandler)).isAccountMaxTradeSizeActive(actions[i]));
+        } 
+
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply the rules to all actions
+        setAccountMaxTradeSizeRuleFull(address(applicationNFTHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule id's were cleared correctly and actions deactivated
+        for (uint i; i < ruleIds.length; i++) {
+            assertEq(TradingRuleFacet(address(applicationNFTHandler)).getAccountMaxTradeSizeId(actions[i]), 0);
+            assertFalse(TradingRuleFacet(address(applicationNFTHandler)).isAccountMaxTradeSizeActive(actions[i]));
+        } 
+    }
+
     function testERC721_ERC721CommonTests_TokenMaxBuySellVolumeTreasuryerRule_AllowListPass() public endWithStopPrank {
         uint16 tokenPercentageSell = 30; /// 0.30%
         _tokenMaxBuySellVolumeTreasuryerRuleSetupSell();
@@ -1840,6 +1869,36 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         /// and now we test the actual rule with a non-allowlisted address to check it will fail
         vm.expectRevert(0xfa006f25);
         _testSellNFT(erc721Liq / 2 + 100 + (erc721Liq * tokenPercentageSell) / 10000, amm);
+    }
+
+    function testERC721_ERC721CommonTests_TokenMaxBuySellVolumeFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](2);
+        // Set up rules
+        ruleIds[0] = createTokenMaxBuySellVolumeRule(25, 48, 0, Blocktime);
+        ruleIds[1] = createTokenMaxBuySellVolumeRule(25, 24, 0, Blocktime);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.SELL, ActionTypes.BUY);
+        
+        // Apply the rules to all actions
+        setTokenMaxBuySellVolumeIdFull(address(applicationNFTHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(TradingRuleFacet(address(applicationNFTHandler)).getTokenMaxBuySellVolumeId(actions[i]), ruleIds[i]);
+            assertTrue(TradingRuleFacet(address(applicationNFTHandler)).isTokenMaxBuySellVolumeActive(actions[i]));
+        } 
+
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+        
+        // Apply zero length actions
+        setTokenMaxBuySellVolumeIdFull(address(applicationNFTHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule id's were set correctly
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(TradingRuleFacet(address(applicationNFTHandler)).getTokenMaxBuySellVolumeId(actions[i]), 0);
+            assertFalse(TradingRuleFacet(address(applicationNFTHandler)).isTokenMaxBuySellVolumeActive(actions[i]));
+        } 
     }
 
     /* TokenMaxDailyTrades */
@@ -1890,6 +1949,38 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMaxDailyTradesActive(ActionTypes.MINT));
     }
 
+    function testERC721_ERC721CommonTests_TokenMaxDailyTradesAtomicFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](4);
+        // Set up rules
+        ruleIds[0] = createTokenMaxDailyTradesRule("PudgyPlatypuses1", "Dudeles", 1, 5);
+        ruleIds[1] = createTokenMaxDailyTradesRule("PudgyPlatypuses2", "Dudeles", 1, 15);
+        ruleIds[2] = createTokenMaxDailyTradesRule("PudgyPlatypuses3", "Dudeles", 1, 25);
+        ruleIds[3] = createTokenMaxDailyTradesRule("PudgyPlatypuses4", "Dudeles", 1, 35);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.P2P_TRANSFER, ActionTypes.SELL, ActionTypes.BUY, ActionTypes.MINT);
+        
+        // Apply the rules to all actions
+        setTokenMaxDailyTradesRuleFull(address(applicationNFTHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).getTokenMaxDailyTradesId(actions[i]), ruleIds[i]);
+            assertTrue(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMaxDailyTradesActive(actions[i]));
+        } 
+
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply new zero length rules
+        setTokenMaxDailyTradesRuleFull(address(applicationNFTHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rules were cleared and deactivated
+        for (uint i; i < ruleIds.length; ++i) {
+            assertEq(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).getTokenMaxDailyTradesId(actions[i]), 0);
+            assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMaxDailyTradesActive(actions[i]));
+        } 
+    }
+
     /* TokenMinHoldTime */
     function testERC721_ERC721CommonTests_TokenMinHoldTimeAtomicFullSet() public endWithStopPrank {
         uint32[] memory periods = new uint32[](5);
@@ -1908,7 +1999,7 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         for (uint i; i < 5; i++) assertTrue(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinHoldTimeActive(ActionTypes(i)));
     }
 
-    function ttestERC721_ERC721CommonTests_TokenMinHoldTimeAtomicFullReSet() public endWithStopPrank {
+    function testERC721_ERC721CommonTests_TokenMinHoldTimeAtomicFullReSet() public endWithStopPrank {
         uint32[] memory periods = new uint32[](5);
         // Set up rule
         for (uint i; i < periods.length; i++) periods[i] = uint32(i + 1);
@@ -1936,6 +2027,35 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinHoldTimeActive(ActionTypes.P2P_TRANSFER));
         assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinHoldTimeActive(ActionTypes.MINT));
         assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinHoldTimeActive(ActionTypes.BURN));
+    }
+
+    function testERC721_ERC721CommonTests_TokenMinHoldTimeAtomicFull_ZeroLengthActions() public endWithStopPrank {
+        uint32[] memory periods = new uint32[](5);
+        // Set up rules
+        for (uint i; i < periods.length; i++) periods[i] = uint32(i + 1);
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.P2P_TRANSFER, ActionTypes.SELL, ActionTypes.BUY, ActionTypes.MINT, ActionTypes.BURN);
+        
+        // Apply the rules to all actions
+        setTokenMinHoldTimeRuleFull(address(applicationNFTHandler), actions, periods);
+
+        // Verify that all the rule id's were set correctly and activated
+        for (uint i; i < periods.length; ++i) {
+            assertEq(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).getTokenMinHoldTimePeriod(actions[i]), periods[i]);
+            assertTrue(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinHoldTimeActive(actions[i]));
+        }
+
+        // Create zero length arrays
+        uint32[] memory periodsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply new zero length rules
+        setTokenMinHoldTimeRuleFull(address(applicationNFTHandler), actionsZero, periodsZero);
+
+        // Verify that all rules were cleared and actions deactivated
+        for (uint i; i < periods.length; ++i) {
+            assertEq(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).getTokenMinHoldTimePeriod(actions[i]), 0);
+            assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isTokenMinHoldTimeActive(actions[i]));
+        }
     }
 
     /* AccountApproveDenyOracle */
@@ -2045,6 +2165,45 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         }
     }
 
+      function testERC721_ERC721CommonTests_AccountApproveDenyOracleRulefull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](25);
+        ActionTypes[] memory actions = new ActionTypes[](25);
+
+        // Set up rules
+        uint256 actionIndex;
+        uint256 mainIndex;
+        for (uint i; i < 5; i++) {
+            for (uint j; j < 5; j++) {
+                actions[mainIndex] = ActionTypes(actionIndex);
+                ruleIds[mainIndex] = createAccountApproveDenyOracleRule(0);
+                mainIndex++;
+            }
+            actionIndex++;
+        }
+
+        // Apply the rules to all actions
+        setAccountApproveDenyOracleRuleFull(address(applicationNFTHandler), actions, ruleIds);
+        
+        // Verify that all the rule id's were set correctly and are active
+        for (uint i; i < 5; ++i) {
+            assertEq(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).getAccountApproveDenyOracleIds(actions[i])[i], ruleIds[i]);
+            assertTrue(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isAccountApproveDenyOracleActive(actions[i], ruleIds[i]));
+        }
+
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+
+        // Apply zero length arrays
+        setAccountApproveDenyOracleRuleFull(address(applicationNFTHandler), actionsZero, ruleIdsZero);
+        
+        // Verify that all the rule ids were cleared and not active
+        for (uint i; i < 5; ++i) {
+            assertEq(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).getAccountApproveDenyOracleIds(actions[i]).length, 0);
+            assertFalse(ERC721NonTaggedRuleFacet(address(applicationNFTHandler)).isAccountApproveDenyOracleActive(actions[i], ruleIds[i]));
+        }
+    }
+
     /* TokenMinimumTransaction */
     function testERC721_ERC721CommonTests_TokenMinimumTransactionAtomicFullSet() public endWithStopPrank {
         uint32[] memory ruleIds = new uint32[](5);
@@ -2143,6 +2302,36 @@ abstract contract ERC721CommonTests is TestCommonFoundry, ERC721Util {
         assertFalse(ERC721TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(ActionTypes.P2P_TRANSFER));
         assertFalse(ERC721TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(ActionTypes.MINT));
         assertFalse(ERC721TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(ActionTypes.BURN));
+    }
+
+    function testERC721_ERC721CommonTests_AccountMinMaxTokenBalanceAtomicFull_ZeroLengthActions() public {
+        uint32[] memory ruleIds = new uint32[](5);
+        // Set up rule
+        bytes32[5] memory tags = [bytes32("Oscar"), bytes32("RJ"), bytes32("Tayler"), bytes32("Michael"), bytes32("Shane")];
+        for (uint i; i < ruleIds.length; i++) createAccountMinMaxTokenBalanceRule(createBytes32Array(tags[i]), createUint256Array(i + 1), createUint256Array((i + 1) * 1000));
+        ActionTypes[] memory actions = createActionTypeArray(ActionTypes.P2P_TRANSFER, ActionTypes.SELL, ActionTypes.BUY, ActionTypes.MINT, ActionTypes.BURN);
+        
+        // Apply the rules to all actions
+        setAccountMinMaxTokenBalanceRuleFull(address(applicationCoinHandler), actions, ruleIds);
+
+        // Verify that all the rule id's were set correctly
+        for (uint i; i < 5; i++) {
+            assertEq(ERC721TaggedRuleFacet(address(applicationCoinHandler)).getAccountMinMaxTokenBalanceId(actions[i]), ruleIds[i]);
+            assertTrue(ERC721TaggedRuleFacet(address(applicationCoinHandler)).isAccountMinMaxTokenBalanceActive(actions[i]));
+        }
+        
+        // Create zero length arrays
+        uint32[] memory ruleIdsZero = new uint32[](0);
+        ActionTypes[] memory actionsZero = new ActionTypes[](0);
+        
+        // Apply the rules to all actions
+        setAccountMinMaxTokenBalanceRuleFull(address(applicationCoinHandler), actionsZero, ruleIdsZero);
+
+        // Verify that all the rule ids were cleared and not active
+        for (uint i; i < 5; i++) {
+            assertEq(ERC721TaggedRuleFacet(address(applicationNFTHandler)).getAccountMinMaxTokenBalanceId(actions[i]), 0);
+            assertFalse(ERC721TaggedRuleFacet(address(applicationNFTHandler)).isAccountMinMaxTokenBalanceActive(actions[i]));
+        }
     }
 
     function testERC721_ERC721CommonTests_getAccTotalValuation_TestGasLimitBreakageNFTsValueLimitLow() public {

--- a/test/client/token/ERC721/util/ERC721Util.sol
+++ b/test/client/token/ERC721/util/ERC721Util.sol
@@ -56,6 +56,16 @@ abstract contract ERC721Util is TokenUtils, DummyNFTAMM {
         ERC721TaggedRuleFacet(address(assetHandler)).setAccountMinMaxTokenBalanceId(actionTypes, ruleId);
     }
 
+    function setAccountMaxTradeSizeRuleFull(address assetHandler, ActionTypes[] memory actions, uint32[] memory ruleIds) public endWithStopPrank {
+        switchToRuleAdmin();
+        TradingRuleFacet(address(assetHandler)).setAccountMaxTradeSizeIdFull(actions, ruleIds);
+    }
+
+    function setTokenMaxBuySellVolumeIdFull(address assetHandler, ActionTypes[] memory actions, uint32[] memory ruleIds) public endWithStopPrank {
+        switchToRuleAdmin();
+        TradingRuleFacet(address(assetHandler)).setTokenMaxBuySellVolumeIdFull(actions, ruleIds);
+    }
+
     function setAccountMinMaxTokenBalanceRuleSingleAction(ActionTypes action, address assetHandler, uint32 ruleId) public endWithStopPrank {
         switchToRuleAdmin();
         ERC721TaggedRuleFacet(address(assetHandler)).setAccountMinMaxTokenBalanceId(createActionTypeArray(action), ruleId);


### PR DESCRIPTION
Removed check for 0 length actions array input argument from all atomic full rule set functions. Added tests for each.