### PR TITLE
Invariant failure investigation

### DIFF
--- a/test/client/token/ERC20/invariant/ApplicationERC20MintBurn.t.i.sol
+++ b/test/client/token/ERC20/invariant/ApplicationERC20MintBurn.t.i.sol
@@ -9,7 +9,6 @@ import "./ApplicationERC20Common.t.i.sol";
  * @dev This is the invariant test for ERC20 mint/burn functionality.
  */
 contract ApplicationERC20MintBurnInvariantTest is ApplicationERC20Common {
-
     function setUp() public {
         prepERC20AndEnvironment();
     }
@@ -18,56 +17,40 @@ contract ApplicationERC20MintBurnInvariantTest is ApplicationERC20Common {
     function invariant_ERC20external_burn() public {
         uint256 balance_sender = applicationCoin.balanceOf(USER1);
         uint256 supply = applicationCoin.totalSupply();
-        if(!(balance_sender > 0))return;
+        if (!(balance_sender > 0)) return;
         uint256 burn_amount = amount % (balance_sender + 1);
 
         vm.startPrank(USER1, USER1);
         applicationCoin.burn(burn_amount);
-        assertEq(
-            applicationCoin.balanceOf(USER1),
-            balance_sender - burn_amount
-        );
-        assertEq(
-            applicationCoin.totalSupply(),
-            supply - burn_amount
-        );
+        assertEq(applicationCoin.balanceOf(USER1), balance_sender - burn_amount);
+        assertEq(applicationCoin.totalSupply(), supply - burn_amount);
     }
 
     // Burn should update user balance and total supply when burnFrom is called twice
     function invariant_ERC20external_burnFrom() public {
         uint256 balance_sender = applicationCoin.balanceOf(USER1);
         uint256 allowance = applicationCoin.allowance(USER1, USER2);
-        if(!(balance_sender > 0 && allowance > balance_sender))return;
+        if (!(balance_sender > 0 && allowance > balance_sender)) return;
         uint256 supply = applicationCoin.totalSupply();
         uint256 burn_amount = amount % (balance_sender + 1);
-
+        vm.startPrank(USER2);
         applicationCoin.burnFrom(USER1, burn_amount);
-        assertEq(
-            applicationCoin.balanceOf(USER1),
-            balance_sender - burn_amount
-        );
-        assertEq(
-            applicationCoin.totalSupply(),
-            supply - burn_amount
-        );
+        assertEq(applicationCoin.balanceOf(USER1), balance_sender - burn_amount);
+        assertEq(applicationCoin.totalSupply(), supply - burn_amount);
     }
 
     // burnFrom should update allowance
     function invariant_ERC20external_burnFromUpdateAllowance() public {
         uint256 balance_sender = applicationCoin.balanceOf(USER1);
         uint256 current_allowance = applicationCoin.allowance(USER1, address(this));
-        if(!(balance_sender > 0 && current_allowance > balance_sender))return;
+        if (!(balance_sender > 0 && current_allowance > balance_sender)) return;
         uint256 burn_amount = amount % (balance_sender + 1);
 
         applicationCoin.burnFrom(USER1, burn_amount);
 
         // Some implementations take an allowance of 2**256-1 as infinite, and therefore don't update
         if (current_allowance != type(uint256).max) {
-            assertEq(
-                applicationCoin.allowance(USER1, address(this)),
-                current_allowance - burn_amount
-            );
+            assertEq(applicationCoin.allowance(USER1, address(this)), current_allowance - burn_amount);
         }
     }
-
 }

--- a/test/protocol/economic/invariant/rules/accountApproveDenyOracle/RuleStorageAccountApproveDenyOracleMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountApproveDenyOracle/RuleStorageAccountApproveDenyOracleMulti.t.i.sol
@@ -64,6 +64,7 @@ contract RuleStorageAccountApproveDenyOracleMultiTest is RuleStorageInvariantCom
     function invariant_rulesTotalAccountApproveDenyOracleIncrementsByOne() public {
         uint256 previousTotal = ERC20RuleProcessorFacet(address(ruleProcessor)).getTotalAccountApproveDenyOracle();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, RuleDataFacet(address(ruleProcessor)).addAccountApproveDenyOracle(address(applicationAppManager), 0, address(0xabc)));
     }
 

--- a/test/protocol/economic/invariant/rules/accountMaxTradeSize/RuleStorageAccountMaxTradeSizeMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountMaxTradeSize/RuleStorageAccountMaxTradeSizeMulti.t.i.sol
@@ -70,6 +70,7 @@ contract RuleStorageAccountMaxTradeSizeMultiTest is RuleStorageInvariantCommon {
     function invariant_rulesTotalAccountMaxTradeSizeIncrementsByOne() public {
         uint256 previousTotal = ERC20TaggedRuleProcessorFacet(address(ruleProcessor)).getTotalAccountMaxTradeSize();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(
             previousTotal,
             TaggedRuleDataFacet(address(ruleProcessor)).addAccountMaxTradeSize(

--- a/test/protocol/economic/invariant/rules/accountMaxTxValueByRiskScore/RuleStorageAccountMaxTxValueByRiskScoreMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountMaxTxValueByRiskScore/RuleStorageAccountMaxTxValueByRiskScoreMulti.t.i.sol
@@ -64,6 +64,7 @@ contract RuleStorageAccountMaxTxValueByRiskScoreMultiTest is RuleStorageInvarian
     function invariant_rulesTotalAccountMaxTxValueByRiskScoreIncrementsByOne() public {
         uint256 previousTotal = ApplicationRiskProcessorFacet(address(ruleProcessor)).getTotalAccountMaxTxValueByRiskScore();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(
             previousTotal,
             AppRuleDataFacet(address(ruleProcessor)).addAccountMaxTxValueByRiskScore(address(applicationAppManager), createUint48Array(100), createUint8Array(50), 24, uint64(block.timestamp))

--- a/test/protocol/economic/invariant/rules/accountMaxValueByAccessLevel/RuleStorageAccountMaxValueByAccessLevelMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountMaxValueByAccessLevel/RuleStorageAccountMaxValueByAccessLevelMulti.t.i.sol
@@ -68,6 +68,7 @@ contract RuleStorageAccountMaxValueByAccessLevelMultiTest is RuleStorageInvarian
     function invariant_rulesTotalAccountMaxValueByAccessLevelIncrementsByOne() public {
         uint256 previousTotal = ApplicationAccessLevelProcessorFacet(address(ruleProcessor)).getTotalAccountMaxValueByAccessLevel();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, AppRuleDataFacet(address(ruleProcessor)).addAccountMaxValueByAccessLevel(address(applicationAppManager), createUint48Array(666, 667, 668, 669, 670)));
     }
 

--- a/test/protocol/economic/invariant/rules/accountMaxValueByRisk/RuleStorageAccountMaxValueByRiskScoreMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountMaxValueByRisk/RuleStorageAccountMaxValueByRiskScoreMulti.t.i.sol
@@ -64,6 +64,7 @@ contract RuleStorageAccountMaxValueByRiskScoreMultiTest is RuleStorageInvariantC
     function invariant_rulesTotalAccountMaxValueByRiskScoreIncrementsByOne() public {
         uint256 previousTotal = ApplicationRiskProcessorFacet(address(ruleProcessor)).getTotalAccountMaxValueByRiskScore();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, AppRuleDataFacet(address(ruleProcessor)).addAccountMaxValueByRiskScore(address(applicationAppManager), createUint8Array(50), createUint48Array(100)));
     }
 

--- a/test/protocol/economic/invariant/rules/accountMaxValueOutByAccessLevel/RuleStorageAccountMaxValueOutByAccessLevelMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountMaxValueOutByAccessLevel/RuleStorageAccountMaxValueOutByAccessLevelMulti.t.i.sol
@@ -68,6 +68,7 @@ contract RuleStorageAccountMaxValueOutByAccessLevelMultiTest is RuleStorageInvar
     function invariant_rulesTotalAccountMaxValueOutByAccessLevelIncrementsByOne() public {
         uint256 previousTotal = ApplicationAccessLevelProcessorFacet(address(ruleProcessor)).getTotalAccountMaxValueOutByAccessLevel();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, AppRuleDataFacet(address(ruleProcessor)).addAccountMaxValueOutByAccessLevel(address(applicationAppManager), createUint48Array(666, 667, 668, 669, 670)));
     }
 

--- a/test/protocol/economic/invariant/rules/accountMinMaxTokenBalance/RuleStorageAccountMinMaxTokenBalanceMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/accountMinMaxTokenBalance/RuleStorageAccountMinMaxTokenBalanceMulti.t.i.sol
@@ -71,6 +71,7 @@ contract RuleStorageAccountMinMaxTokenBalanceMultiTest is RuleStorageInvariantCo
     function invariant_rulesTotalAccountMinMaxTokenBalanceIncrementsByOne() public {
         uint256 previousTotal = ERC20TaggedRuleProcessorFacet(address(ruleProcessor)).getTotalAccountMinMaxTokenBalances();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(
             previousTotal,
             TaggedRuleDataFacet(address(ruleProcessor)).addAccountMinMaxTokenBalance(

--- a/test/protocol/economic/invariant/rules/tokenMaxBuySellVolume/RuleStorageTokenMaxBuySellVolumeMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/tokenMaxBuySellVolume/RuleStorageTokenMaxBuySellVolumeMulti.t.i.sol
@@ -65,7 +65,7 @@ contract RuleStorageTokenMaxBuySellVolumeMultiTest is RuleStorageInvariantCommon
     function invariant_rulesTotalTokenMaxBuySellVolumeIncrementsByOne() public {
         uint256 previousTotal = ERC20RuleProcessorFacet(address(ruleProcessor)).getTotalTokenMaxBuySellVolume();
         // not incrementing previousTotal by one due to zero based ruleId
-        switchToAccessLevelAdmin();
+        switchToRuleAdmin();
         assertEq(previousTotal, RuleDataFacet(address(ruleProcessor)).addTokenMaxBuySellVolume(address(applicationAppManager), 5000, 24, 0xffffffffffff, uint64(block.timestamp)));
     }
 

--- a/test/protocol/economic/invariant/rules/tokenMaxBuySellVolume/RuleStorageTokenMaxBuySellVolumeMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/tokenMaxBuySellVolume/RuleStorageTokenMaxBuySellVolumeMulti.t.i.sol
@@ -65,6 +65,7 @@ contract RuleStorageTokenMaxBuySellVolumeMultiTest is RuleStorageInvariantCommon
     function invariant_rulesTotalTokenMaxBuySellVolumeIncrementsByOne() public {
         uint256 previousTotal = ERC20RuleProcessorFacet(address(ruleProcessor)).getTotalTokenMaxBuySellVolume();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToAccessLevelAdmin();
         assertEq(previousTotal, RuleDataFacet(address(ruleProcessor)).addTokenMaxBuySellVolume(address(applicationAppManager), 5000, 24, 0xffffffffffff, uint64(block.timestamp)));
     }
 

--- a/test/protocol/economic/invariant/rules/tokenMaxDailyTrades/RuleStorageTokenMaxDailyTradesMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/tokenMaxDailyTrades/RuleStorageTokenMaxDailyTradesMulti.t.i.sol
@@ -64,6 +64,7 @@ contract RuleStorageTokenMaxDailyTradesMultiTest is RuleStorageInvariantCommon {
     function invariant_rulesTotalTokenMaxDailyTradesIncrementsByOne() public {
         uint256 previousTotal = ERC721TaggedRuleProcessorFacet(address(ruleProcessor)).getTotalTokenMaxDailyTrades();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(
             previousTotal,
             TaggedRuleDataFacet(address(ruleProcessor)).addTokenMaxDailyTrades(address(applicationAppManager), createBytes32Array(bytes32("tag")), createUint8Array(222), uint64(block.timestamp))

--- a/test/protocol/economic/invariant/rules/tokenMaxSupplyVolatility/RuleStorageTokenMaxSupplyVolatilityMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/tokenMaxSupplyVolatility/RuleStorageTokenMaxSupplyVolatilityMulti.t.i.sol
@@ -64,6 +64,7 @@ contract RuleStorageTokenMaxSupplyVolatilityMultiTest is RuleStorageInvariantCom
     function invariant_rulesTotalTokenMaxSupplyVolatilityIncrementsByOne() public {
         uint256 previousTotal = ERC20RuleProcessorFacet(address(ruleProcessor)).getTotalTokenMaxSupplyVolatility();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, RuleDataFacet(address(ruleProcessor)).addTokenMaxSupplyVolatility(address(applicationAppManager), 666, 24, uint64(block.timestamp), 0));
     }
 

--- a/test/protocol/economic/invariant/rules/tokenMaxTradingVolume/RuleStorageTokenMaxTradingVolumeMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/tokenMaxTradingVolume/RuleStorageTokenMaxTradingVolumeMulti.t.i.sol
@@ -64,6 +64,7 @@ contract RuleStorageTokenMaxTradingVolumeMultiTest is RuleStorageInvariantCommon
     function invariant_rulesTotalTokenMaxTradingVolumeIncrementsByOne() public {
         uint256 previousTotal = ERC20RuleProcessorFacet(address(ruleProcessor)).getTotalTokenMaxTradingVolume();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, RuleDataFacet(address(ruleProcessor)).addTokenMaxTradingVolume(address(applicationAppManager), 666, 24, uint64(block.timestamp), 0));
     }
 

--- a/test/protocol/economic/invariant/rules/tokenMinTxSize/RuleStorageTokenMinTxSizeMulti.t.i.sol
+++ b/test/protocol/economic/invariant/rules/tokenMinTxSize/RuleStorageTokenMinTxSizeMulti.t.i.sol
@@ -22,9 +22,9 @@ contract RuleStorageTokenMinTxSizeMultiTest is RuleStorageInvariantCommon {
             ApplicationAppManager actorAppManager = _createAppManager();
             switchToSuperAdmin();
             actorAppManager.addAppAdministrator(appAdministrator);
+            vm.startPrank(appAdministrator);
             actors.push(new RuleStorageTokenMinTxSizeActor(ruleProcessor, actorAppManager));
             if (i % 2 == 0) {
-                vm.startPrank(appAdministrator);
                 actorAppManager.addRuleAdministrator(address(actors[actors.length - 1]));
             }
         }
@@ -64,6 +64,7 @@ contract RuleStorageTokenMinTxSizeMultiTest is RuleStorageInvariantCommon {
     function invariant_rulesTotalMinTxSizeIncrementsByOne() public {
         uint256 previousTotal = ERC20RuleProcessorFacet(address(ruleProcessor)).getTotalTokenMinTxSize();
         // not incrementing previousTotal by one due to zero based ruleId
+        switchToRuleAdmin();
         assertEq(previousTotal, RuleDataFacet(address(ruleProcessor)).addTokenMinTxSize(address(applicationAppManager), 1));
     }
 


### PR DESCRIPTION
It looks like Foundry doesn't allow anymore uncaught reversions in the invariant tests. The failing invariant tests were fixed.