### PR TITLE
Small tweak to abi-aggregator to respect the package.json version

### DIFF
--- a/abi-aggregator.mjs
+++ b/abi-aggregator.mjs
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import { existsSync, mkdirSync } from "fs"
 
-const outputDir = "doom-abis"
+const outputDir = `doom-abis/${pkgjson.version}`
 
 if (process.argv.length != 4 || process.argv[2] != "--branch") {
   console.log("Usage: node abi-aggregator.mjs --branch <repo branch>")

--- a/docker-scripts/deploy.sh
+++ b/docker-scripts/deploy.sh
@@ -17,6 +17,9 @@ source script/ParseApplicationDeploy.sh 1
 forge script script/clientScripts/Application_Deploy_02_ApplicationFT1.s.sol --ffi --broadcast
 source script/ParseApplicationDeploy.sh 2
 forge script script/clientScripts/Application_Deploy_02_ApplicationFT1Pt2.s.sol --ffi --broadcast
+forge script script/clientScripts/Application_Deploy_03_ApplicationFT2.s.sol --ffi --broadcast
+source script/ParseApplicationDeploy.sh 6
+forge script script/clientScripts/Application_Deploy_03_ApplicationFT2Pt2.s.sol --ffi --broadcast
 forge script script/clientScripts/Application_Deploy_04_ApplicationNFT.s.sol --ffi --broadcast
 forge script script/clientScripts/Application_Deploy_04_ApplicationNFTUpgradeable.s.sol --ffi --broadcast
 source script/ParseApplicationDeploy.sh 3


### PR DESCRIPTION
number, and a change to the docker deploy script to give us 2 ERC20 tokens in the off-chain dev environment

Just small changes for some things related to off-chain land CI and dev workflow. 