### PR TITLE
Removes .git from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,7 +23,6 @@ coverage.xml
 .hypothesis
 
 # Other files
-.env
 .DS_Store
 # Test binary, built with `go test -c`
 *.test

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,7 +18,6 @@ nosetests.xml
 coverage.xml
 *.cover
 *.log
-.git
 .mypy_cache
 .pytest_cache
 .hypothesis


### PR DESCRIPTION
This was likely preventing submodules from being included, breaking the image-builder workflow.

Merge if https://github.com/thrackle-io/rules-engine/actions/runs/10948247753 succeeds.
