### PR TITLE
DemoSetup script - anvil already running error catch

### DIFF
--- a/script/demo/DemoSetup.sh
+++ b/script/demo/DemoSetup.sh
@@ -7,7 +7,7 @@ echo a env file will be created with all of the relevant address exports at .tes
 echo "################################################################"
 echo
 
-OUTPUTFILE="test_env"
+OUTPUTFILE=".test_env"
 
 ENV_FILE=".env"
 

--- a/script/demo/DemoSetup.sh
+++ b/script/demo/DemoSetup.sh
@@ -45,6 +45,12 @@ if [ "$LOCAL" = "y" ]; then
     anvil --gas-limit 80000000 &> ./anvil_output.txt &
     sleep 8
 
+    # Check for the error message in anvil_output.txt
+    if grep -q "Error: Address already in use" anvil_output.txt; then
+        echo "Error: Address already in use. Is anvil running already? Please stop the existing anvil process and try again."
+        exit 1
+    fi
+
     # Parsing anvil output to grab an adress and its private key
     ARRAY=$(cat anvil_output.txt | grep \(0\) | tr '\n' ' ')
     IFS=' ' read -r -a array <<< "$ARRAY"


### PR DESCRIPTION
If anvil (or something else on port 8545) is already running, anvil will fail to start in the demo script. This just adds a quick check for the error in anvil_output.txt and prints a message for the user if caught. 

This also sets the output filename to be `.test_env` instead of `test_env` to match the message. 