### PR TITLE
docs: fixes links to the license files in reference docs

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -73,14 +73,14 @@ Please visit our [Contributor Guide][contributorGuide-url].
 
 ## Licensing
 
-The primary license for Forte Protocol Rules Engine is the Business Source License 1.1 (`BUSL-1.1`), see [`LICENSE`](./LICENSE). However, some files are dual licensed under `GPL-2.0-or-later`:
+The primary license for Forte Protocol Rules Engine is the Business Source License 1.1 (`BUSL-1.1`), see [`LICENSE`](/LICENSE). However, some files are dual licensed under `GPL-2.0-or-later`:
 
-- All files in `src/example/` may also be licensed under `GPL-2.0-or-later` (as indicated in their SPDX headers), see [`src/example/LICENSE`](./src/example/LICENSE)
+- All files in `src/example/` may also be licensed under `GPL-2.0-or-later` (as indicated in their SPDX headers), see [`src/example/LICENSE`](/src/example/LICENSE)
 
 ### Other Exceptions
 
-- All files in `lib/` are licensed under `MIT` (as indicated in its SPDX header), see [`lib/LICENSE_MIT`](lib/LICENSE_MIT)
-- All files in `src/example/` may also be licensed under `GPL-2.0-or-later` (as indicated in their SPDX headers), see [src/example/LICENSE](src/example/LICENSE)
+- All files in `lib/` are licensed under `MIT` (as indicated in its SPDX header), see [`lib/LICENSE_MIT`](/lib/LICENSE_MIT)
+- All files in `src/example/` may also be licensed under `GPL-2.0-or-later` (as indicated in their SPDX headers), see [src/example/LICENSE](/src/example/LICENSE)
 Other Exceptions
 - All files in `contracts/test` remain unlicensed (as indicated in their SPDX headers).
 


### PR DESCRIPTION
Noticed the links to license files were not working in docs/src/README.md. This fixes them. 