### PR TITLE
Removed references to renamed rule (Max Transaction Size Per Period)

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -107,7 +107,6 @@ Rule deactivation is done by sending a "false" boolean along with the no longer 
 | [Account Max Tx Value By Risk Score](./userGuides/rules/ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md)| ERC20/ERC721 | mint/buy/sell/transfer |
 | [Oracle](./userGuides/rules/ACCOUNT-APPROVE-DENY-ORACLE.md) | ERC20/ERC721/AMM | mint/buy/sell/transfer |
 | [Pause Rule](./userGuides/rules/PAUSE-RULE.md) | Application | mint/burn/buy/sell/transfer |
-| [Transaction Size Per Time Period by Risk Score](./userGuides/rules/ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md) | Application | mint/buy/sell/transfer |
 
 ## Rule Applicibility Controls
 

--- a/docs/userGuides/rules/ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md
+++ b/docs/userGuides/rules/ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md
@@ -50,7 +50,7 @@ maxValue = [500, 250, 50];
 ***risk scores can be between 0 and 100.***
 
 ```c
-/// ******** Transaction Size Per Period Rules ********
+/// ******** Account Max Transaction Value By Period Rules ********
 struct AccountMaxTxValueByRiskScore {
         uint48[] maxValue; /// whole USD (no cents) -> 1 = 1 USD (Max allowed: 281 trillion USD)
         uint8[] riskScore;
@@ -63,7 +63,7 @@ struct AccountMaxTxValueByRiskScore {
 These rules are stored in a mapping indexed by ruleId(uint32) in order of creation:
 
 ```c
- /// ******** Transaction Size Per Period Rules ********
+ /// ******** Account Max Transaction Value By Period Rules ********
     struct AccountMaxTxValueByRiskScoreS {
         mapping(uint32 => IApplicationRules.AccountMaxTxValueByRiskScore) accountMaxTxValueByRiskScoreRules;
         uint32 accountMaxTxValueByRiskScoreIndex;

--- a/docs/userGuides/rules/RULE-APPLICABILITY.md
+++ b/docs/userGuides/rules/RULE-APPLICABILITY.md
@@ -22,7 +22,6 @@
 | [Oracle](./ACCOUNT-APPROVE-DENY-ORACLE.md) | ERC20/ERC721/AMM | mint/buy/sell/transfer |
 | [Oracle Flexible](./ACCOUNT-APPROVE-DENY-ORACLE-FLEXIBLE.md) | ERC20/ERC721/AMM | mint/buy/sell/transfer |
 | [Pause Rule](./PAUSE-RULE.md) | Application | mint/burn/buy/sell/transfer |
-| [Transaction Size Per Time Period by Risk Score](./ACCOUNT-MAX-TX-VALUE-BY-RISK-SCORE.md) | Application | mint/buy/sell/transfer |
 
 
 <!-- These are the header links -->


### PR DESCRIPTION
Removed from docs/userGuide/rules