### PR TITLE
SE-1160-Set-Rules-Engine-Version-properly-for-all-2.1.0-deployments

### DIFF
--- a/script/DeployAllModulesPt3.s.sol
+++ b/script/DeployAllModulesPt3.s.sol
@@ -31,6 +31,7 @@ contract DeployAllModulesPt3Script is Script, DiamondScriptUtil, DeployABIUtil {
     address ownerAddress;
     bool recordAllChains;
     uint256 timestamp;
+    string private constant VERSION="2.2.0";
 
     /**
      * @dev This is the main function that gets called by the Makefile or CLI
@@ -98,7 +99,7 @@ contract DeployAllModulesPt3Script is Script, DiamondScriptUtil, DeployABIUtil {
         IDiamondCut(ruleProcessorAddress).diamondCut(_facetCutsRuleProcessor, address(0x0), "");
 
         // Set the version
-        VersionFacet(ruleProcessorAddress).updateVersion("2.2.0");
+        VersionFacet(ruleProcessorAddress).updateVersion(VERSION);
 
         setENVVariable("RECORD_DEPLOYMENTS_FOR_ALL_CHAINS", "false");
     }

--- a/script/DeployAllModulesPt3.s.sol
+++ b/script/DeployAllModulesPt3.s.sol
@@ -12,6 +12,7 @@ import {TaggedRuleDataFacet} from "src/protocol/economic/ruleProcessor/TaggedRul
 import {RuleDataFacet} from "src/protocol/economic/ruleProcessor/RuleDataFacet.sol";
 import {DiamondScriptUtil} from "./DiamondScriptUtil.sol";
 import {DeployABIUtil} from "./DeployABIUtil.sol";
+import {VersionFacet} from "src/protocol/diamond/VersionFacet.sol";
 
 /**
  * @title The final deployment script for the Protocol. It deploys the final set of facets.
@@ -95,6 +96,9 @@ contract DeployAllModulesPt3Script is Script, DiamondScriptUtil, DeployABIUtil {
         address ruleProcessorAddress = vm.envAddress("RULE_PROCESSOR_DIAMOND");
 
         IDiamondCut(ruleProcessorAddress).diamondCut(_facetCutsRuleProcessor, address(0x0), "");
+
+        // Set the version
+        VersionFacet(ruleProcessorAddress).updateVersion("2.2.0");
 
         setENVVariable("RECORD_DEPLOYMENTS_FOR_ALL_CHAINS", "false");
     }

--- a/script/versioning/upgrade_version.sh
+++ b/script/versioning/upgrade_version.sh
@@ -4,7 +4,7 @@
 # Script designed specifically for this repository to change versions in the src and test directories as well  #
 # as in the package.json file.                                                                                 #
 #                                                                                                              #
-# Usage:                                                                                                       #
+# Usage:    cd script/versioning                                                                                                 #
 #           ./upgrade_version.sh <MAJOR.MINOR.MICRO>                                                           #
 #                                                                                                              #
 # Notice that there are no quotation marks in the version.                                                     #
@@ -81,6 +81,9 @@ main() {
     # replace in script
     replace_version_in_abi_script "../python/record_abi.py" "$new_version"
     replace_version_in_abi_script "../python/record_facets.py" "$new_version"
+
+    # replace in deployment script
+    replace_version_in_src "../DeployAllModulesPt3.s.sol" "$new_version"
     
     # replace in readme
     replace_version_in_readme "../../README.md"  "$new_version"


### PR DESCRIPTION
Fixed to properly set RulesProcessorDiamond version on fresh deployments and updated the versioning script to keep the set version in sync.