### PR TITLE
fix: Prevent Slither-action from reinstalling Foundry

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -39,6 +39,10 @@ jobs:
           forge install OpenZeppelin/openzeppelin-contracts
           npm install
 
+      ## Prevent `crytic/slither-action` from re-installing Foundry:<latest>. 
+      ## See https://github.com/crytic/slither-action/issues/44#issuecomment-1338183656
+      - run: rm foundry.toml
+
       - name: Slither Analyze
         uses: crytic/slither-action@v0.3.1
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
The `cryptic/slither-action` in the failing workflow is reinstalling foundry. This implements a workaround, to investigate if this is the root cause of the failing workflow.